### PR TITLE
feat: [07] 商品管理ドメインを実装する

### DIFF
--- a/src/SalesManagementApp.Core/Application/Services/ProductService.cs
+++ b/src/SalesManagementApp.Core/Application/Services/ProductService.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+using SalesManagementApp.Core.Application.Exceptions;
+using SalesManagementApp.Core.Domain.Entities;
+
+namespace SalesManagementApp.Core.Application.Services;
+
+public class ProductService
+{
+    public IReadOnlyList<Product> GetAll(IReadOnlyCollection<Product> products)
+    {
+        return products.OrderBy(p => p.ProductId).ToList();
+    }
+
+    public void Register(ICollection<Product> products, Product input)
+    {
+        Validate(input);
+
+        if (products.Any(p => p.ProductId == input.ProductId))
+        {
+            throw new DomainValidationException("同じ商品IDが既に存在します。");
+        }
+
+        products.Add(Clone(input));
+    }
+
+    public void Update(ICollection<Product> products, Product input)
+    {
+        Validate(input);
+
+        var target = products.FirstOrDefault(p => p.ProductId == input.ProductId);
+        if (target is null)
+        {
+            throw new DomainValidationException("更新対象の商品が存在しません。");
+        }
+
+        target.ProductName = input.ProductName.Trim();
+        target.UnitPrice = input.UnitPrice;
+        target.Category = input.Category.Trim();
+    }
+
+    public void Delete(ICollection<Product> products, string productId)
+    {
+        if (string.IsNullOrWhiteSpace(productId))
+        {
+            throw new DomainValidationException("商品IDは必須です。");
+        }
+
+        var target = products.FirstOrDefault(p => p.ProductId == productId.Trim());
+        if (target is null)
+        {
+            throw new DomainValidationException("削除対象の商品が存在しません。");
+        }
+
+        products.Remove(target);
+    }
+
+    public void Validate(Product product)
+    {
+        if (string.IsNullOrWhiteSpace(product.ProductId))
+        {
+            throw new DomainValidationException("商品IDは必須です。");
+        }
+
+        if (string.IsNullOrWhiteSpace(product.ProductName))
+        {
+            throw new DomainValidationException("商品名は必須です。");
+        }
+
+        if (string.IsNullOrWhiteSpace(product.Category))
+        {
+            throw new DomainValidationException("区分は必須です。");
+        }
+
+        if (product.UnitPrice < 0)
+        {
+            throw new DomainValidationException("単価は0以上である必要があります。");
+        }
+    }
+
+    private static Product Clone(Product input)
+    {
+        return new Product
+        {
+            ProductId = input.ProductId.Trim(),
+            ProductName = input.ProductName.Trim(),
+            UnitPrice = input.UnitPrice,
+            Category = input.Category.Trim()
+        };
+    }
+}

--- a/tests/SalesManagementApp.Tests/Product/ProductServiceTests.cs
+++ b/tests/SalesManagementApp.Tests/Product/ProductServiceTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using SalesManagementApp.Core.Application.Exceptions;
+using SalesManagementApp.Core.Application.Services;
+using SalesManagementApp.Tests.TestHelpers;
+
+namespace SalesManagementApp.Tests.Product;
+
+public class ProductServiceTests
+{
+    private ProductService _service = null!;
+    private List<SalesManagementApp.Core.Domain.Entities.Product> _products = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _service = new ProductService();
+        _products = new List<SalesManagementApp.Core.Domain.Entities.Product>();
+    }
+
+    [Test]
+    public void Register_WhenInputIsValid_AddsProduct()
+    {
+        var product = new ProductBuilder().WithId("P100").Build();
+
+        _service.Register(_products, product);
+
+        Assert.That(_products.Count, Is.EqualTo(1));
+        Assert.That(_products[0].ProductId, Is.EqualTo("P100"));
+    }
+
+    [Test]
+    public void Register_WhenProductIdIsDuplicate_ThrowsValidationException()
+    {
+        _products.Add(new ProductBuilder().WithId("P001").Build());
+        var duplicate = new ProductBuilder().WithId("P001").Build();
+
+        Assert.That(() => _service.Register(_products, duplicate), Throws.TypeOf<DomainValidationException>());
+    }
+
+    [Test]
+    public void Register_WhenPriceIsNegative_ThrowsValidationException()
+    {
+        var invalid = new ProductBuilder().WithPrice(-1).Build();
+
+        Assert.That(() => _service.Register(_products, invalid), Throws.TypeOf<DomainValidationException>());
+    }
+
+    [Test]
+    public void Update_WhenProductExists_UpdatesFields()
+    {
+        _products.Add(new ProductBuilder().WithId("P001").WithName("Old").Build());
+        var update = new ProductBuilder().WithId("P001").WithName("New").WithPrice(999).WithCategory("Snack").Build();
+
+        _service.Update(_products, update);
+
+        Assert.That(_products[0].ProductName, Is.EqualTo("New"));
+        Assert.That(_products[0].UnitPrice, Is.EqualTo(999));
+        Assert.That(_products[0].Category, Is.EqualTo("Snack"));
+    }
+
+    [Test]
+    public void Delete_WhenProductExists_RemovesProduct()
+    {
+        _products.Add(new ProductBuilder().WithId("P001").Build());
+
+        _service.Delete(_products, "P001");
+
+        Assert.That(_products, Is.Empty);
+    }
+}

--- a/tests/SalesManagementApp.Tests/SanityTests.cs
+++ b/tests/SalesManagementApp.Tests/SanityTests.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using SalesManagementApp.Core.Domain.Entities;
 
 namespace SalesManagementApp.Tests;
 
@@ -14,7 +13,13 @@ public class SanityTests
     [Test]
     public void CoreProjectReference_ShouldBeAvailable()
     {
-        var product = new Product { ProductId = "P001", ProductName = "Sample", UnitPrice = 100, Category = "Drink" };
+        var product = new SalesManagementApp.Core.Domain.Entities.Product
+        {
+            ProductId = "P001",
+            ProductName = "Sample",
+            UnitPrice = 100,
+            Category = "Drink"
+        };
         Assert.That(product.ProductId, Is.EqualTo("P001"));
     }
 }

--- a/tests/SalesManagementApp.Tests/TestHelpers/ProductBuilder.cs
+++ b/tests/SalesManagementApp.Tests/TestHelpers/ProductBuilder.cs
@@ -1,10 +1,8 @@
-using SalesManagementApp.Core.Domain.Entities;
-
 namespace SalesManagementApp.Tests.TestHelpers;
 
 public class ProductBuilder
 {
-    private readonly Product _product = new()
+    private readonly SalesManagementApp.Core.Domain.Entities.Product _product = new()
     {
         ProductId = "P001",
         ProductName = "Cola",
@@ -36,5 +34,5 @@ public class ProductBuilder
         return this;
     }
 
-    public Product Build() => _product;
+    public SalesManagementApp.Core.Domain.Entities.Product Build() => _product;
 }


### PR DESCRIPTION
## 目的
- Issue [07] の商品管理ロジック（CRUD/必須/重複/単価チェック）を実装するため。

## 変更点
- ProductService を追加（登録/更新/削除/バリデーション）。
- 商品ドメインルールのNUnitテストを追加。
- テスト名前空間衝突を回避するため、既存テストの型参照を明示化。

## 確認結果
- ローカルで dotnet test 成功（14件）。
- ローカルで WinForms build 成功。
- CI自動テストの通過を確認してからマージする。

Closes #12