### PR TITLE
feat: [09] 在庫管理ドメインを実装する

### DIFF
--- a/src/SalesManagementApp.Core/Application/Services/InventoryService.cs
+++ b/src/SalesManagementApp.Core/Application/Services/InventoryService.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Linq;
+using SalesManagementApp.Core.Application.Exceptions;
+using SalesManagementApp.Core.Domain.Entities;
+
+namespace SalesManagementApp.Core.Application.Services;
+
+public class InventoryService
+{
+    private readonly object _syncRoot = new();
+
+    public IReadOnlyList<InventoryRecord> GetAll(IReadOnlyCollection<InventoryRecord> records)
+    {
+        return records.OrderBy(r => r.StoreId).ThenBy(r => r.ProductId).ToList();
+    }
+
+    public IReadOnlyList<InventoryRecord> GetReorderTargets(IReadOnlyCollection<InventoryRecord> records, int threshold = 5)
+    {
+        return records.Where(r => r.Stock <= threshold).OrderBy(r => r.StoreId).ThenBy(r => r.ProductId).ToList();
+    }
+
+    public void AddStock(ICollection<InventoryRecord> records, string storeId, string productId, int quantity)
+    {
+        ValidateIds(storeId, productId);
+        if (quantity <= 0)
+        {
+            throw new DomainValidationException("入荷数量は1以上である必要があります。");
+        }
+
+        lock (_syncRoot)
+        {
+            var target = FindOrCreate(records, storeId, productId);
+            target.Stock += quantity;
+        }
+    }
+
+    public void RemoveStock(ICollection<InventoryRecord> records, string storeId, string productId, int quantity)
+    {
+        ValidateIds(storeId, productId);
+        if (quantity <= 0)
+        {
+            throw new DomainValidationException("出庫数量は1以上である必要があります。");
+        }
+
+        lock (_syncRoot)
+        {
+            var target = records.FirstOrDefault(r => r.StoreId == storeId && r.ProductId == productId);
+            if (target is null)
+            {
+                throw new DomainValidationException("対象在庫が存在しません。");
+            }
+
+            if (target.Stock < quantity)
+            {
+                throw new DomainValidationException("在庫が不足しています。");
+            }
+
+            target.Stock -= quantity;
+        }
+    }
+
+    private static void ValidateIds(string storeId, string productId)
+    {
+        if (string.IsNullOrWhiteSpace(storeId))
+        {
+            throw new DomainValidationException("StoreId は必須です。");
+        }
+
+        if (string.IsNullOrWhiteSpace(productId))
+        {
+            throw new DomainValidationException("ProductId は必須です。");
+        }
+    }
+
+    private static InventoryRecord FindOrCreate(ICollection<InventoryRecord> records, string storeId, string productId)
+    {
+        var target = records.FirstOrDefault(r => r.StoreId == storeId && r.ProductId == productId);
+        if (target is not null)
+        {
+            return target;
+        }
+
+        target = new InventoryRecord
+        {
+            StoreId = storeId,
+            ProductId = productId,
+            Stock = 0
+        };
+        records.Add(target);
+        return target;
+    }
+}

--- a/tests/SalesManagementApp.Tests/Inventory/InventoryServiceTests.cs
+++ b/tests/SalesManagementApp.Tests/Inventory/InventoryServiceTests.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SalesManagementApp.Core.Application.Exceptions;
+using SalesManagementApp.Core.Application.Services;
+using SalesManagementApp.Tests.TestHelpers;
+
+namespace SalesManagementApp.Tests.Inventory;
+
+public class InventoryServiceTests
+{
+    private InventoryService _service = null!;
+    private List<SalesManagementApp.Core.Domain.Entities.InventoryRecord> _records = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _service = new InventoryService();
+        _records = new List<SalesManagementApp.Core.Domain.Entities.InventoryRecord>();
+    }
+
+    [Test]
+    public void AddStock_WhenRecordNotExists_CreatesAndAddsStock()
+    {
+        _service.AddStock(_records, "S001", "P001", 3);
+
+        Assert.That(_records.Count, Is.EqualTo(1));
+        Assert.That(_records[0].Stock, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void RemoveStock_WhenStockIsInsufficient_ThrowsValidationException()
+    {
+        _records.Add(new InventoryRecordBuilder().WithStoreId("S001").WithProductId("P001").WithStock(2).Build());
+
+        Assert.That(() => _service.RemoveStock(_records, "S001", "P001", 3), Throws.TypeOf<DomainValidationException>());
+    }
+
+    [Test]
+    public void GetReorderTargets_WhenStockIsLessThanOrEqualToThreshold_ReturnsTargets()
+    {
+        _records.Add(new InventoryRecordBuilder().WithStoreId("S001").WithProductId("P001").WithStock(5).Build());
+        _records.Add(new InventoryRecordBuilder().WithStoreId("S001").WithProductId("P002").WithStock(6).Build());
+
+        var targets = _service.GetReorderTargets(_records, 5);
+
+        Assert.That(targets.Count, Is.EqualTo(1));
+        Assert.That(targets[0].ProductId, Is.EqualTo("P001"));
+    }
+
+    [Test]
+    public void AddStock_WhenConcurrentRequestsOccur_UpdatesWithoutDataLoss()
+    {
+        _records.Add(new InventoryRecordBuilder().WithStoreId("S001").WithProductId("P001").WithStock(0).Build());
+
+        var tasks = Enumerable.Range(0, 30)
+            .Select(_ => Task.Run(() => _service.AddStock(_records, "S001", "P001", 1)))
+            .ToArray();
+        Task.WaitAll(tasks);
+
+        Assert.That(_records[0].Stock, Is.EqualTo(30));
+    }
+}


### PR DESCRIPTION
## 目的
- Issue [09] の在庫ロジック（入荷/出庫/要発注/排他制御）を実装するため。

## 変更点
- InventoryService を追加。
  - 入荷（AddStock）
  - 出庫（RemoveStock）
  - 要発注抽出（GetReorderTargets）
  - lock による排他制御
- NUnitテストを追加（正常/不足/閾値/同時更新）。

## 確認結果
- ローカルで dotnet test 成功（18件）。
- ローカルで WinForms build 成功。
- CI自動テストの通過を確認してからマージする。

Closes #14