### PR TITLE
[11] 売上登録ドメインを実装（売上記録・在庫連動）

### DIFF
--- a/src/SalesManagementApp.Core/Application/Services/SalesService.cs
+++ b/src/SalesManagementApp.Core/Application/Services/SalesService.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SalesManagementApp.Core.Application.Exceptions;
+using SalesManagementApp.Core.Domain.Entities;
+
+namespace SalesManagementApp.Core.Application.Services;
+
+public class SalesService
+{
+    public IReadOnlyList<SaleRecord> GetAll(IReadOnlyCollection<SaleRecord> sales)
+    {
+        return sales
+            .OrderByDescending(s => s.SaleDate)
+            .ThenBy(s => s.StoreId)
+            .ThenBy(s => s.ProductId)
+            .ToList();
+    }
+
+    public SaleRecord RegisterSale(
+        ICollection<SaleRecord> sales,
+        IReadOnlyCollection<Product> products,
+        ICollection<InventoryRecord> inventories,
+        SaleRecord input)
+    {
+        ValidateInput(input);
+
+        var product = products.FirstOrDefault(p => p.ProductId == input.ProductId.Trim());
+        if (product is null)
+        {
+            throw new DomainValidationException("存在しない商品です。");
+        }
+
+        var inventory = inventories.FirstOrDefault(i =>
+            i.StoreId == input.StoreId.Trim() &&
+            i.ProductId == input.ProductId.Trim());
+
+        if (inventory is null || inventory.Stock < input.Quantity)
+        {
+            throw new DomainValidationException("在庫が不足しています。");
+        }
+
+        var record = new SaleRecord
+        {
+            SaleDate = input.SaleDate,
+            StoreId = input.StoreId.Trim(),
+            ProductId = input.ProductId.Trim(),
+            Quantity = input.Quantity,
+            SalesAmount = checked(product.UnitPrice * input.Quantity)
+        };
+
+        inventory.Stock -= input.Quantity;
+        sales.Add(record);
+
+        return record;
+    }
+
+    private static void ValidateInput(SaleRecord input)
+    {
+        if (input.SaleDate == default)
+        {
+            throw new DomainValidationException("販売日は必須です。");
+        }
+
+        if (string.IsNullOrWhiteSpace(input.StoreId))
+        {
+            throw new DomainValidationException("StoreId は必須です。");
+        }
+
+        if (string.IsNullOrWhiteSpace(input.ProductId))
+        {
+            throw new DomainValidationException("ProductId は必須です。");
+        }
+
+        if (input.Quantity <= 0)
+        {
+            throw new DomainValidationException("数量は1以上で入力してください。");
+        }
+    }
+}

--- a/tests/SalesManagementApp.Tests/Sales/SalesServiceTests.cs
+++ b/tests/SalesManagementApp.Tests/Sales/SalesServiceTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using SalesManagementApp.Core.Application.Exceptions;
+using SalesManagementApp.Core.Application.Services;
+using SalesManagementApp.Core.Domain.Entities;
+using SalesManagementApp.Tests.TestHelpers;
+using CoreProduct = SalesManagementApp.Core.Domain.Entities.Product;
+
+namespace SalesManagementApp.Tests.Sales;
+
+public class SalesServiceTests
+{
+    private SalesService _service = null!;
+    private List<SaleRecord> _sales = null!;
+    private List<CoreProduct> _products = null!;
+    private List<InventoryRecord> _inventories = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _service = new SalesService();
+        _sales = new List<SaleRecord>();
+        _products = new List<CoreProduct>
+        {
+            new ProductBuilder().WithId("P001").WithName("Cola").WithPrice(120).WithCategory("Drink").Build()
+        };
+        _inventories = new List<InventoryRecord>
+        {
+            new InventoryRecordBuilder().WithStoreId("S001").WithProductId("P001").WithStock(10).Build()
+        };
+    }
+
+    [Test]
+    public void RegisterSale_WhenInputIsValid_AddsSaleAndReducesInventory()
+    {
+        var input = new SaleRecordBuilder().WithDate(new DateTime(2026, 3, 1)).WithStoreId("S001").WithProductId("P001").WithQuantity(3).Build();
+
+        var registered = _service.RegisterSale(_sales, _products, _inventories, input);
+
+        Assert.That(_sales.Count, Is.EqualTo(1));
+        Assert.That(registered.SalesAmount, Is.EqualTo(360));
+        Assert.That(_inventories[0].Stock, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void RegisterSale_WhenStockIsInsufficient_ThrowsValidationException()
+    {
+        var input = new SaleRecordBuilder().WithStoreId("S001").WithProductId("P001").WithQuantity(11).Build();
+
+        Assert.That(() => _service.RegisterSale(_sales, _products, _inventories, input), Throws.TypeOf<DomainValidationException>());
+        Assert.That(_sales.Count, Is.EqualTo(0));
+        Assert.That(_inventories[0].Stock, Is.EqualTo(10));
+    }
+
+    [Test]
+    public void RegisterSale_WhenProductNotFound_ThrowsValidationException()
+    {
+        var input = new SaleRecordBuilder().WithStoreId("S001").WithProductId("P999").WithQuantity(1).Build();
+
+        Assert.That(() => _service.RegisterSale(_sales, _products, _inventories, input), Throws.TypeOf<DomainValidationException>());
+    }
+
+    [Test]
+    public void RegisterSale_WhenQuantityIsNotPositive_ThrowsValidationException()
+    {
+        var input = new SaleRecordBuilder().WithStoreId("S001").WithProductId("P001").WithQuantity(0).Build();
+
+        Assert.That(() => _service.RegisterSale(_sales, _products, _inventories, input), Throws.TypeOf<DomainValidationException>());
+    }
+}


### PR DESCRIPTION
﻿## 概要
売上登録ドメインを追加し、売上金額計算と在庫連動を実装しました。

## 変更内容
- `SalesService`を追加
  - 売上登録（販売日/店舗ID/商品ID/数量）
  - 売上金額計算（`単価 x 数量`）
  - 在庫減算連動
  - 在庫不足・商品未存在・入力不備のバリデーション
- `SalesServiceTests`を追加（NUnit）
  - 正常系: 売上登録時の在庫減算と売上金額計算
  - 異常系: 在庫不足、商品未存在、数量不正

## 動作確認
- `dotnet build "Sales Management App/Sales Management App.slnx"`
- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj`

Closes #16
