### PR TITLE
[13] 売上集計ドメインを実装（期間別・商品別集計）

### DIFF
--- a/src/SalesManagementApp.Core/Application/Models/SalesAggregationResult.cs
+++ b/src/SalesManagementApp.Core/Application/Models/SalesAggregationResult.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace SalesManagementApp.Core.Application.Models;
+
+public class ProductSalesSummary
+{
+    public string ProductId { get; set; } = string.Empty;
+    public int TotalQuantity { get; set; }
+    public int TotalSalesAmount { get; set; }
+}
+
+public class WeeklySalesSummary
+{
+    public DateTime WeekStartDate { get; set; }
+    public DateTime WeekEndDate { get; set; }
+    public int TotalQuantity { get; set; }
+    public int TotalSalesAmount { get; set; }
+}

--- a/src/SalesManagementApp.Core/Application/Services/SalesAggregationService.cs
+++ b/src/SalesManagementApp.Core/Application/Services/SalesAggregationService.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SalesManagementApp.Core.Application.Exceptions;
+using SalesManagementApp.Core.Application.Models;
+using SalesManagementApp.Core.Domain.Entities;
+
+namespace SalesManagementApp.Core.Application.Services;
+
+public class SalesAggregationService
+{
+    public IReadOnlyList<SaleRecord> FilterByPeriod(
+        IReadOnlyCollection<SaleRecord> sales,
+        DateTime startDate,
+        DateTime endDate)
+    {
+        ValidatePeriod(startDate, endDate);
+
+        var start = startDate.Date;
+        var end = endDate.Date;
+
+        return sales
+            .Where(s => s.SaleDate.Date >= start && s.SaleDate.Date <= end)
+            .OrderBy(s => s.SaleDate)
+            .ThenBy(s => s.StoreId)
+            .ThenBy(s => s.ProductId)
+            .ToList();
+    }
+
+    public IReadOnlyList<ProductSalesSummary> GetProductSummaries(
+        IReadOnlyCollection<SaleRecord> sales,
+        DateTime startDate,
+        DateTime endDate)
+    {
+        return FilterByPeriod(sales, startDate, endDate)
+            .GroupBy(s => s.ProductId)
+            .Select(g => new ProductSalesSummary
+            {
+                ProductId = g.Key,
+                TotalQuantity = g.Sum(x => x.Quantity),
+                TotalSalesAmount = g.Sum(x => x.SalesAmount)
+            })
+            .OrderBy(x => x.ProductId)
+            .ToList();
+    }
+
+    public IReadOnlyList<WeeklySalesSummary> GetWeeklySummaries(
+        IReadOnlyCollection<SaleRecord> sales,
+        DateTime startDate,
+        DateTime endDate)
+    {
+        return FilterByPeriod(sales, startDate, endDate)
+            .GroupBy(s => GetWeekStartDate(s.SaleDate.Date))
+            .Select(g =>
+            {
+                var weekStart = g.Key;
+                return new WeeklySalesSummary
+                {
+                    WeekStartDate = weekStart,
+                    WeekEndDate = weekStart.AddDays(6),
+                    TotalQuantity = g.Sum(x => x.Quantity),
+                    TotalSalesAmount = g.Sum(x => x.SalesAmount)
+                };
+            })
+            .OrderBy(x => x.WeekStartDate)
+            .ToList();
+    }
+
+    public int GetTotalSalesAmount(
+        IReadOnlyCollection<SaleRecord> sales,
+        DateTime startDate,
+        DateTime endDate)
+    {
+        return FilterByPeriod(sales, startDate, endDate).Sum(s => s.SalesAmount);
+    }
+
+    private static void ValidatePeriod(DateTime startDate, DateTime endDate)
+    {
+        if (startDate.Date > endDate.Date)
+        {
+            throw new DomainValidationException("開始日は終了日以前で指定してください。");
+        }
+    }
+
+    private static DateTime GetWeekStartDate(DateTime date)
+    {
+        const DayOfWeek day = DayOfWeek.Monday;
+        var diff = (7 + (date.DayOfWeek - day)) % 7;
+        return date.AddDays(-diff);
+    }
+}

--- a/tests/SalesManagementApp.Tests/Sales/SalesAggregationServiceTests.cs
+++ b/tests/SalesManagementApp.Tests/Sales/SalesAggregationServiceTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using SalesManagementApp.Core.Application.Exceptions;
+using SalesManagementApp.Core.Application.Services;
+using SalesManagementApp.Tests.TestHelpers;
+
+namespace SalesManagementApp.Tests.Sales;
+
+public class SalesAggregationServiceTests
+{
+    private SalesAggregationService _service = null!;
+    private List<SalesManagementApp.Core.Domain.Entities.SaleRecord> _sales = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _service = new SalesAggregationService();
+        _sales = new List<SalesManagementApp.Core.Domain.Entities.SaleRecord>
+        {
+            new SaleRecordBuilder().WithDate(new DateTime(2026, 3, 1)).WithStoreId("S001").WithProductId("P001").WithQuantity(2).WithSalesAmount(200).Build(),
+            new SaleRecordBuilder().WithDate(new DateTime(2026, 3, 2)).WithStoreId("S001").WithProductId("P001").WithQuantity(1).WithSalesAmount(100).Build(),
+            new SaleRecordBuilder().WithDate(new DateTime(2026, 3, 3)).WithStoreId("S001").WithProductId("P002").WithQuantity(3).WithSalesAmount(450).Build(),
+            new SaleRecordBuilder().WithDate(new DateTime(2026, 3, 8)).WithStoreId("S002").WithProductId("P002").WithQuantity(2).WithSalesAmount(300).Build(),
+            new SaleRecordBuilder().WithDate(new DateTime(2026, 3, 10)).WithStoreId("S001").WithProductId("P001").WithQuantity(1).WithSalesAmount(100).Build()
+        };
+    }
+
+    [Test]
+    public void FilterByPeriod_IncludesBoundaryDates()
+    {
+        var result = _service.FilterByPeriod(_sales, new DateTime(2026, 3, 1), new DateTime(2026, 3, 8));
+
+        Assert.That(result.Count, Is.EqualTo(4));
+        Assert.That(result.First().SaleDate.Date, Is.EqualTo(new DateTime(2026, 3, 1)));
+        Assert.That(result.Last().SaleDate.Date, Is.EqualTo(new DateTime(2026, 3, 8)));
+    }
+
+    [Test]
+    public void GetProductSummaries_ReturnsAmountAndQuantityByProduct()
+    {
+        var summaries = _service.GetProductSummaries(_sales, new DateTime(2026, 3, 1), new DateTime(2026, 3, 8));
+        var p001 = summaries.Single(s => s.ProductId == "P001");
+        var p002 = summaries.Single(s => s.ProductId == "P002");
+
+        Assert.That(p001.TotalQuantity, Is.EqualTo(3));
+        Assert.That(p001.TotalSalesAmount, Is.EqualTo(300));
+        Assert.That(p002.TotalQuantity, Is.EqualTo(5));
+        Assert.That(p002.TotalSalesAmount, Is.EqualTo(750));
+    }
+
+    [Test]
+    public void GetWeeklySummaries_ReturnsWeeklyTotals()
+    {
+        var summaries = _service.GetWeeklySummaries(_sales, new DateTime(2026, 3, 1), new DateTime(2026, 3, 8));
+
+        Assert.That(summaries.Count, Is.EqualTo(2));
+        Assert.That(summaries[0].TotalSalesAmount, Is.EqualTo(200));
+        Assert.That(summaries[1].TotalSalesAmount, Is.EqualTo(850));
+    }
+
+    [Test]
+    public void GetTotalSalesAmount_ReturnsPeriodAmount()
+    {
+        var total = _service.GetTotalSalesAmount(_sales, new DateTime(2026, 3, 1), new DateTime(2026, 3, 8));
+
+        Assert.That(total, Is.EqualTo(1050));
+    }
+
+    [Test]
+    public void FilterByPeriod_WhenStartDateIsAfterEndDate_ThrowsValidationException()
+    {
+        Assert.That(
+            () => _service.FilterByPeriod(_sales, new DateTime(2026, 3, 9), new DateTime(2026, 3, 8)),
+            Throws.TypeOf<DomainValidationException>());
+    }
+}


### PR DESCRIPTION
﻿## 概要
売上集計ドメインを追加し、期間・商品別・週次の集計ロジックを実装しました。

## 変更内容
- `SalesAggregationService`を追加
  - 期間フィルタ（境界日付含む）
  - 商品別売上金額/販売数量集計
  - 週次集計（月曜開始）
  - 期間合計売上金額算出
- 集計結果モデルを追加
  - `ProductSalesSummary`
  - `WeeklySalesSummary`
- `SalesAggregationServiceTests`を追加（NUnit）
  - 既知データセットで手計算一致を検証
  - 境界日付ケース
  - 不正期間（開始日>終了日）検証

## 動作確認
- `dotnet build "Sales Management App/Sales Management App.slnx"`
- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj`

Closes #18
