### PR TITLE
[17] 非同期処理を導入（UIブロック回避）

### DIFF
--- a/docs/async-processing.md
+++ b/docs/async-processing.md
@@ -1,0 +1,22 @@
+# 非同期処理方針
+
+## 対象
+- CSV I/O（読み込み・書き込み）
+
+## 実装内容
+- `CsvDataStore`に以下の非同期メソッドを追加
+  - `ReadProductsAsync` / `ReadInventoriesAsync` / `ReadSalesAsync`
+  - `WriteProductsAsync` / `WriteInventoriesAsync` / `WriteSalesAsync`
+- いずれも `Task.Run` + `CancellationToken` に対応し、呼び出し側でUIスレッドをブロックしない利用が可能。
+
+## キャンセル評価
+- CSV処理はデータ量により待ち時間が増えるため、キャンセル要求を受け付ける価値がある。
+- `CancellationToken`を受け取り、実行前に `ThrowIfCancellationRequested` を行う設計とした。
+
+## 検証
+- NUnit
+  - 非同期読み込み成功
+  - キャンセル時に `OperationCanceledException` 系が発生
+- ビルド
+  - `dotnet build "Sales Management App/Sales Management App.slnx"`
+

--- a/src/SalesManagementApp.Core/Infrastructure/Csv/CsvDataStore.cs
+++ b/src/SalesManagementApp.Core/Infrastructure/Csv/CsvDataStore.cs
@@ -4,6 +4,8 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using SalesManagementApp.Core.Application.Exceptions;
 using SalesManagementApp.Core.Domain.Entities;
 using SalesManagementApp.Core.Infrastructure.DataProtection;
@@ -51,6 +53,15 @@ public class CsvDataStore
         return result;
     }
 
+    public Task<IReadOnlyList<Product>> ReadProductsAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ReadProducts(filePath);
+        }, cancellationToken);
+    }
+
     public IReadOnlyList<InventoryRecord> ReadInventories(string filePath)
     {
         var rows = ReadDataRows(filePath, "StoreId,ProductId,Stock");
@@ -70,6 +81,15 @@ public class CsvDataStore
         }
 
         return result;
+    }
+
+    public Task<IReadOnlyList<InventoryRecord>> ReadInventoriesAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ReadInventories(filePath);
+        }, cancellationToken);
     }
 
     public IReadOnlyList<SaleRecord> ReadSales(string filePath)
@@ -94,11 +114,29 @@ public class CsvDataStore
         return result;
     }
 
+    public Task<IReadOnlyList<SaleRecord>> ReadSalesAsync(string filePath, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ReadSales(filePath);
+        }, cancellationToken);
+    }
+
     public void WriteProducts(string filePath, IEnumerable<Product> products)
     {
         var lines = new List<string> { "ProductId,ProductName,UnitPrice,Category" };
         lines.AddRange(products.Select(p => $"{p.ProductId},{p.ProductName},{p.UnitPrice},{p.Category}"));
         WriteAllLines(filePath, lines);
+    }
+
+    public Task WriteProductsAsync(string filePath, IEnumerable<Product> products, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            WriteProducts(filePath, products);
+        }, cancellationToken);
     }
 
     public void WriteInventories(string filePath, IEnumerable<InventoryRecord> records)
@@ -108,12 +146,30 @@ public class CsvDataStore
         WriteAllLines(filePath, lines);
     }
 
+    public Task WriteInventoriesAsync(string filePath, IEnumerable<InventoryRecord> records, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            WriteInventories(filePath, records);
+        }, cancellationToken);
+    }
+
     public void WriteSales(string filePath, IEnumerable<SaleRecord> records)
     {
         var lines = new List<string> { "SaleDate,StoreId,ProductId,Quantity" };
         lines.AddRange(records.Select(r =>
             $"{r.SaleDate:yyyy-MM-dd},{r.StoreId},{r.ProductId},{r.Quantity}"));
         WriteAllLines(filePath, lines);
+    }
+
+    public Task WriteSalesAsync(string filePath, IEnumerable<SaleRecord> records, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            WriteSales(filePath, records);
+        }, cancellationToken);
     }
 
     public IReadOnlyList<string> GetBackups(string filePath)

--- a/tests/SalesManagementApp.Tests/Csv/CsvDataStoreTests.cs
+++ b/tests/SalesManagementApp.Tests/Csv/CsvDataStoreTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using SalesManagementApp.Core.Application.Exceptions;
 using SalesManagementApp.Core.Domain.Entities;
@@ -144,5 +146,36 @@ public class CsvDataStoreTests
         Assert.That(File.Exists(logPath), Is.True);
         var log = File.ReadAllText(logPath);
         Assert.That(log, Does.Contain("Write succeeded"));
+    }
+
+    [Test]
+    public async Task ReadProductsAsync_WhenCsvIsValid_ReturnsProducts()
+    {
+        var path = Path.Combine(_workDir, "products.csv");
+        File.WriteAllLines(path, new[]
+        {
+            "ProductId,ProductName,UnitPrice,Category",
+            "P001,Cola,120,Drink"
+        });
+
+        var result = await _store.ReadProductsAsync(path);
+
+        Assert.That(result.Count, Is.EqualTo(1));
+        Assert.That(result[0].ProductId, Is.EqualTo("P001"));
+    }
+
+    [Test]
+    public void WriteProductsAsync_WhenCanceled_ThrowsOperationCanceledException()
+    {
+        var path = Path.Combine(_workDir, "products.csv");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.That(
+            async () => await _store.WriteProductsAsync(path, new[]
+            {
+                new ProductEntity { ProductId = "P001", ProductName = "Cola", UnitPrice = 120, Category = "Drink" }
+            }, cts.Token),
+            Throws.InstanceOf<OperationCanceledException>());
     }
 }


### PR DESCRIPTION
﻿## 概要
CSV処理を非同期化し、キャンセル可能な実行方式を導入しました。

## 変更内容
- `CsvDataStore`に非同期APIを追加
  - `ReadProductsAsync` / `ReadInventoriesAsync` / `ReadSalesAsync`
  - `WriteProductsAsync` / `WriteInventoriesAsync` / `WriteSalesAsync`
- 非同期APIは `Task.Run` + `CancellationToken` を使用
- キャンセル要求時は `OperationCanceledException` 系で終了
- 検証テストを追加
  - 非同期読み込み成功
  - 非同期書き込みのキャンセル
- 方針文書を追加
  - `docs/async-processing.md`

## 動作確認
- `dotnet build "Sales Management App/Sales Management App.slnx"`
- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj`

Closes #22
