### PR TITLE
feat: [20] 商品名重複禁止を実装

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,4 +115,12 @@
 - 売上CSVは次の2形式を受け入れる。
   - `SaleDate,StoreId,ProductId,Quantity`
   - `SaleDate,StoreId,ProductId,Quantity,SalesAmount`
-- `SalesAmount` 列がない売上CSVを読み込んだ場合は、`products.csv` の単価を使って `UnitPrice * Quantity` で補完する。
+- 4列売上CSVを読み込んだ場合は、`products.csv` の単価を使って `SalesAmount` を算出し、5列形式へ正規化して保存する。
+- 売上CSVは `sales_yyyyMMdd.csv` 形式のみ読込対象とし、最新日付ファイルを優先する。
+
+## 13. 設計/実装ルール（SRP・DRY）
+- クラス/メソッドは単一責務を維持し、責務が増えた場合は分割する。
+- 重複ロジックは共通化し、同一処理を複数箇所へコピペしない。
+- クラス内クラス（nested class）は禁止し、必要な型は独立 `.cs` に切り出す。
+- WinForms の肥大化を避けるため、画面コードは `partial class` やサービスへ責務分離する。
+- 既存仕様を変えない構造リファクタを優先し、仕様変更はIssue単位で明示して実施する。

--- a/src/SalesManagementApp.Core/Application/Services/ProductService.cs
+++ b/src/SalesManagementApp.Core/Application/Services/ProductService.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using SalesManagementApp.Core.Application.Exceptions;
 using SalesManagementApp.Core.Application.Validation;
 using SalesManagementApp.Core.Domain.Entities;
@@ -17,10 +19,16 @@ public class ProductService
     {
         Validate(input);
         var normalizedId = ValidationGuard.RequireNotEmpty(input.ProductId, "商品ID");
+        var normalizedName = NormalizeProductName(input.ProductName);
 
         if (products.Any(p => p.ProductId == normalizedId))
         {
             throw new DomainValidationException("同一の商品IDが既に登録されています。");
+        }
+
+        if (products.Any(p => NormalizeProductName(p.ProductName) == normalizedName))
+        {
+            throw new DomainValidationException("同一の商品名が既に登録されています。");
         }
 
         products.Add(Clone(input));
@@ -30,11 +38,17 @@ public class ProductService
     {
         Validate(input);
         var normalizedId = ValidationGuard.RequireNotEmpty(input.ProductId, "商品ID");
+        var normalizedName = NormalizeProductName(input.ProductName);
 
         var target = products.FirstOrDefault(p => p.ProductId == normalizedId);
         if (target is null)
         {
             throw new DomainValidationException("更新対象の商品が存在しません。");
+        }
+
+        if (products.Any(p => p.ProductId != normalizedId && NormalizeProductName(p.ProductName) == normalizedName))
+        {
+            throw new DomainValidationException("同一の商品名が既に登録されています。");
         }
 
         target.ProductId = normalizedId;
@@ -73,5 +87,13 @@ public class ProductService
             UnitPrice = input.UnitPrice,
             Category = input.Category.Trim()
         };
+    }
+
+    private static string NormalizeProductName(string productName)
+    {
+        var normalized = ValidationGuard.RequireNotEmpty(productName, "商品名")
+            .Normalize(NormalizationForm.FormKC)
+            .ToUpperInvariant();
+        return normalized;
     }
 }

--- a/tests/SalesManagementApp.Tests/Product/ProductServiceTests.cs
+++ b/tests/SalesManagementApp.Tests/Product/ProductServiceTests.cs
@@ -48,6 +48,33 @@ public class ProductServiceTests
     }
 
     [Test]
+    public void Register_WhenProductNameIsDuplicateAfterTrim_ThrowsValidationException()
+    {
+        _products.Add(new ProductBuilder().WithId("P001").WithName("Coffee").Build());
+        var duplicate = new ProductBuilder().WithId("P002").WithName("  Coffee  ").Build();
+
+        Assert.That(() => _service.Register(_products, duplicate), Throws.TypeOf<DomainValidationException>());
+    }
+
+    [Test]
+    public void Register_WhenProductNameDiffersOnlyByCase_ThrowsValidationException()
+    {
+        _products.Add(new ProductBuilder().WithId("P001").WithName("Coffee").Build());
+        var duplicate = new ProductBuilder().WithId("P002").WithName("coffee").Build();
+
+        Assert.That(() => _service.Register(_products, duplicate), Throws.TypeOf<DomainValidationException>());
+    }
+
+    [Test]
+    public void Register_WhenProductNameDiffersOnlyByFullHalfWidth_ThrowsValidationException()
+    {
+        _products.Add(new ProductBuilder().WithId("P001").WithName("ｺｰﾋｰ").Build());
+        var duplicate = new ProductBuilder().WithId("P002").WithName("コーヒー").Build();
+
+        Assert.That(() => _service.Register(_products, duplicate), Throws.TypeOf<DomainValidationException>());
+    }
+
+    [Test]
     public void Register_WhenPriceIsNegative_ThrowsValidationException()
     {
         var invalid = new ProductBuilder().WithPrice(-1).Build();
@@ -80,6 +107,16 @@ public class ProductServiceTests
         Assert.That(_products[0].ProductName, Is.EqualTo("New"));
         Assert.That(_products[0].UnitPrice, Is.EqualTo(999));
         Assert.That(_products[0].Category, Is.EqualTo("Snack"));
+    }
+
+    [Test]
+    public void Update_WhenProductNameDuplicatesAnotherProduct_ThrowsValidationException()
+    {
+        _products.Add(new ProductBuilder().WithId("P001").WithName("Coffee").Build());
+        _products.Add(new ProductBuilder().WithId("P002").WithName("Tea").Build());
+        var update = new ProductBuilder().WithId("P002").WithName(" coffee ").Build();
+
+        Assert.That(() => _service.Update(_products, update), Throws.TypeOf<DomainValidationException>());
     }
 
     [Test]


### PR DESCRIPTION
﻿## 目的
- Issue #50 の要件に基づき、商品名の重複登録/重複更新を禁止する
- 併せて、運用上重要なSRP/DRYルールを `AGENTS.md` へ明記する

## 変更点
- `ProductService` に商品名重複チェックを追加
  - 比較ルール: 前後空白除去 + NFKC正規化 + 大文字小文字無視
  - 登録時: 既存商品に同一商品名があればエラー
  - 更新時: 他商品と同一商品名になる場合はエラー
- `ProductServiceTests` に重複チェックのテストを追加
  - trim差分
  - 大文字小文字差分
  - 全角/半角差分
  - 更新時の重複
- `AGENTS.md` を更新
  - 売上CSV正規化運用の記載更新
  - SRP/DRY・責務分離・nested class禁止ルールを追記

## 確認結果
- `dotnet build "Sales Management App/Sales Management App.slnx"` : 成功
- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj` : 成功（51件合格）

Closes #50
