### PR TITLE
feat: [21] 在庫算出方式変更を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@
 - 既知制約/未対応: `docs/known-limitations.md`
 - リリース判定チェック: `docs/release-checklist.md`
 - E2Eシナリオ/結果: `docs/e2e-scenarios.md`, `docs/e2e-test-report.md`
+- 在庫算出方式: `docs/inventory-calculation.md`
 

--- a/docs/inventory-calculation.md
+++ b/docs/inventory-calculation.md
@@ -1,0 +1,34 @@
+# 在庫算出方式（追加課題対応）
+
+## 1. 変更概要
+- 旧方式: `InventoryService` 内で在庫数を直接 `+/-` する方式。
+- 新方式: `InventoryStockCalculator` に算出責務を分離し、入荷/出庫の在庫計算を専用クラスで実施する方式。
+
+## 2. 差分
+| 観点 | 旧方式 | 新方式 |
+|---|---|---|
+| 算出責務 | `InventoryService` に内包 | `InventoryStockCalculator` に分離 |
+| 入荷計算 | `target.Stock += quantity` | `CalculateAfterInbound` |
+| 出庫計算 | `target.Stock -= quantity` | `CalculateAfterOutbound` |
+| 異常系 | サービス内に散在 | 計算クラスで集中検証 |
+| 上限チェック | 明示なし | `checked` でオーバーフロー検知 |
+
+## 3. 新方式のルール
+- 入荷: `currentStock + inboundQuantity`
+  - 在庫数は0以上
+  - 入荷数量は1以上
+  - 計算結果が `int` 上限を超える場合はエラー
+- 出庫: `currentStock - outboundQuantity`
+  - 在庫数は0以上
+  - 出庫数量は1以上
+  - 在庫不足はエラー
+
+## 4. 既存データの取り扱い
+- `inventory.csv` のスキーマ変更はなし（移行不要）。
+- 既存の在庫残数はそのまま読み込める。
+- 実行時の算出ルールのみ新方式を適用する。
+
+## 5. 実装ポイント
+- `src/SalesManagementApp.Core/Application/Services/InventoryStockCalculator.cs`
+- `src/SalesManagementApp.Core/Application/Services/InventoryService.cs`
+- `tests/SalesManagementApp.Tests/Inventory/InventoryStockCalculatorTests.cs`

--- a/src/SalesManagementApp.Core/Application/Services/InventoryService.cs
+++ b/src/SalesManagementApp.Core/Application/Services/InventoryService.cs
@@ -9,6 +9,17 @@ namespace SalesManagementApp.Core.Application.Services;
 public class InventoryService
 {
     private readonly object _syncRoot = new();
+    private readonly InventoryStockCalculator _stockCalculator;
+
+    public InventoryService()
+        : this(new InventoryStockCalculator())
+    {
+    }
+
+    internal InventoryService(InventoryStockCalculator stockCalculator)
+    {
+        _stockCalculator = stockCalculator;
+    }
 
     public IReadOnlyList<InventoryRecord> GetAll(IReadOnlyCollection<InventoryRecord> records)
     {
@@ -29,7 +40,7 @@ public class InventoryService
         lock (_syncRoot)
         {
             var target = FindOrCreate(records, normalizedStoreId, normalizedProductId);
-            target.Stock += quantity;
+            target.Stock = _stockCalculator.CalculateAfterInbound(target.Stock, quantity);
         }
     }
 
@@ -47,12 +58,7 @@ public class InventoryService
                 throw new DomainValidationException("対象在庫が存在しません。");
             }
 
-            if (target.Stock < quantity)
-            {
-                throw new DomainValidationException("在庫が不足しています。");
-            }
-
-            target.Stock -= quantity;
+            target.Stock = _stockCalculator.CalculateAfterOutbound(target.Stock, quantity);
         }
     }
 

--- a/src/SalesManagementApp.Core/Application/Services/InventoryStockCalculator.cs
+++ b/src/SalesManagementApp.Core/Application/Services/InventoryStockCalculator.cs
@@ -1,0 +1,36 @@
+using System;
+using SalesManagementApp.Core.Application.Exceptions;
+using SalesManagementApp.Core.Application.Validation;
+
+namespace SalesManagementApp.Core.Application.Services;
+
+public class InventoryStockCalculator
+{
+    public int CalculateAfterInbound(int currentStock, int inboundQuantity)
+    {
+        ValidationGuard.RequireNonNegative(currentStock, "在庫数");
+        ValidationGuard.RequirePositive(inboundQuantity, "入荷数量");
+
+        try
+        {
+            return checked(currentStock + inboundQuantity);
+        }
+        catch (OverflowException)
+        {
+            throw new DomainValidationException("在庫算出中に上限を超えました。");
+        }
+    }
+
+    public int CalculateAfterOutbound(int currentStock, int outboundQuantity)
+    {
+        ValidationGuard.RequireNonNegative(currentStock, "在庫数");
+        ValidationGuard.RequirePositive(outboundQuantity, "出庫数量");
+
+        if (currentStock < outboundQuantity)
+        {
+            throw new DomainValidationException("在庫が不足しています。");
+        }
+
+        return currentStock - outboundQuantity;
+    }
+}

--- a/tests/SalesManagementApp.Tests/Inventory/InventoryServiceTests.cs
+++ b/tests/SalesManagementApp.Tests/Inventory/InventoryServiceTests.cs
@@ -61,4 +61,14 @@ public class InventoryServiceTests
 
         Assert.That(_records[0].Stock, Is.EqualTo(30));
     }
+
+    [Test]
+    public void AddStock_WhenStockCalculationOverflows_ThrowsValidationException()
+    {
+        _records.Add(new InventoryRecordBuilder().WithStoreId("S001").WithProductId("P001").WithStock(int.MaxValue).Build());
+
+        Assert.That(
+            () => _service.AddStock(_records, "S001", "P001", 1),
+            Throws.TypeOf<DomainValidationException>());
+    }
 }

--- a/tests/SalesManagementApp.Tests/Inventory/InventoryStockCalculatorTests.cs
+++ b/tests/SalesManagementApp.Tests/Inventory/InventoryStockCalculatorTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using SalesManagementApp.Core.Application.Exceptions;
+using SalesManagementApp.Core.Application.Services;
+
+namespace SalesManagementApp.Tests.Inventory;
+
+public class InventoryStockCalculatorTests
+{
+    private InventoryStockCalculator _calculator = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _calculator = new InventoryStockCalculator();
+    }
+
+    [Test]
+    public void CalculateAfterInbound_WhenInputsAreValid_ReturnsIncreasedStock()
+    {
+        var result = _calculator.CalculateAfterInbound(10, 5);
+
+        Assert.That(result, Is.EqualTo(15));
+    }
+
+    [Test]
+    public void CalculateAfterInbound_WhenResultOverflows_ThrowsValidationException()
+    {
+        Assert.That(
+            () => _calculator.CalculateAfterInbound(int.MaxValue, 1),
+            Throws.TypeOf<DomainValidationException>());
+    }
+
+    [Test]
+    public void CalculateAfterOutbound_WhenInputsAreValid_ReturnsDecreasedStock()
+    {
+        var result = _calculator.CalculateAfterOutbound(10, 4);
+
+        Assert.That(result, Is.EqualTo(6));
+    }
+
+    [Test]
+    public void CalculateAfterOutbound_WhenStockIsInsufficient_ThrowsValidationException()
+    {
+        Assert.That(
+            () => _calculator.CalculateAfterOutbound(3, 4),
+            Throws.TypeOf<DomainValidationException>());
+    }
+}


### PR DESCRIPTION
﻿## 目的
- Issue #52 の要件に基づき、在庫算出方式を責務分離した新方式へ移行する
- 算出根拠を明確化し、将来の方式切替に備える

## 変更点
- `InventoryStockCalculator` を新規追加
  - 入荷後在庫: `CalculateAfterInbound`
  - 出庫後在庫: `CalculateAfterOutbound`
  - 上限超過（overflow）と在庫不足を計算層で検証
- `InventoryService` を更新
  - 在庫の増減計算を `InventoryStockCalculator` へ委譲
  - サービスの責務を在庫レコード管理に集約
- テスト追加/更新
  - `InventoryStockCalculatorTests` を新規追加
  - `InventoryServiceTests` に overflow ケースを追加
- ドキュメント追加
  - `docs/inventory-calculation.md`（旧方式との差分/移行方針）
  - `README.md` にリンク追加

## 確認結果
- `dotnet build "Sales Management App/Sales Management App.slnx"` : 成功
- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj` : 成功（56件合格）

Closes #52
