### PR TITLE
feat: [24] 各タブの一覧表ヘッダーを日本語表示に統一

### DIFF
--- a/Sales Management App/Sales Management App/Form1.Aggregation.cs
+++ b/Sales Management App/Sales Management App/Form1.Aggregation.cs
@@ -81,6 +81,7 @@ namespace Sales_Management_App {
                 s.TotalQuantity,
                 s.TotalSalesAmount
             }).ToList();
+            ApplyJapaneseHeaders(_productSummaryGrid, ProductSummaryGridHeaders);
 
             _weeklySummaryGrid.DataSource = null;
             _weeklySummaryGrid.DataSource = snapshot.WeeklySummaries.Select(s => new {
@@ -88,6 +89,7 @@ namespace Sales_Management_App {
                 s.TotalQuantity,
                 s.TotalSalesAmount
             }).ToList();
+            ApplyJapaneseHeaders(_weeklySummaryGrid, WeeklySummaryGridHeaders);
         }
 
         private void ResetAggregationDisplay() {

--- a/Sales Management App/Sales Management App/Form1.GridHeaders.cs
+++ b/Sales Management App/Sales Management App/Form1.GridHeaders.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace Sales_Management_App {
+    public partial class Form1 {
+        private static readonly IReadOnlyDictionary<string, string> ProductGridHeaders =
+            new Dictionary<string, string> {
+                { "ProductId", "商品ID" },
+                { "ProductName", "商品名" },
+                { "UnitPrice", "単価" },
+                { "Category", "区分" }
+            };
+
+        private static readonly IReadOnlyDictionary<string, string> InventoryGridHeaders =
+            new Dictionary<string, string> {
+                { "StoreId", "店舗ID" },
+                { "ProductId", "商品ID" },
+                { "Stock", "在庫数" }
+            };
+
+        private static readonly IReadOnlyDictionary<string, string> SalesGridHeaders =
+            new Dictionary<string, string> {
+                { "SaleDate", "販売日" },
+                { "StoreId", "店舗ID" },
+                { "ProductId", "商品ID" },
+                { "ProductName", "商品名" },
+                { "Quantity", "数量" },
+                { "SalesAmount", "売上金額" }
+            };
+
+        private static readonly IReadOnlyDictionary<string, string> ProductSummaryGridHeaders =
+            new Dictionary<string, string> {
+                { "ProductId", "商品ID" },
+                { "TotalQuantity", "販売数量" },
+                { "TotalSalesAmount", "売上金額" }
+            };
+
+        private static readonly IReadOnlyDictionary<string, string> WeeklySummaryGridHeaders =
+            new Dictionary<string, string> {
+                { "Week", "週" },
+                { "TotalQuantity", "販売数量" },
+                { "TotalSalesAmount", "売上金額" }
+            };
+
+        private static readonly IReadOnlyDictionary<string, string> InventoryHistoryGridHeaders =
+            new Dictionary<string, string> {
+                { "OccurredAt", "日時" },
+                { "OperationType", "操作種別" },
+                { "StoreId", "店舗ID" },
+                { "ProductId", "商品ID" },
+                { "Quantity", "数量" },
+                { "ResultStock", "実行後在庫" },
+                { "Result", "実行結果" }
+            };
+
+        private static void ApplyJapaneseHeaders(DataGridView grid, IReadOnlyDictionary<string, string> headers) {
+            if (grid == null || headers == null) {
+                return;
+            }
+
+            foreach (DataGridViewColumn column in grid.Columns) {
+                string text;
+                if (headers.TryGetValue(column.Name, out text)) {
+                    column.HeaderText = text;
+                }
+            }
+        }
+    }
+}

--- a/Sales Management App/Sales Management App/Form1.Inventory.cs
+++ b/Sales Management App/Sales Management App/Form1.Inventory.cs
@@ -55,6 +55,7 @@ namespace Sales_Management_App {
                 r.ProductId,
                 r.Stock
             }).ToList();
+            ApplyJapaneseHeaders(_inventoryGrid, InventoryGridHeaders);
 
             var reorderCount = _inventoryService.GetReorderTargets(_inventories, 5).Count;
             _reorderLabel.Text = string.Format("要発注（在庫5以下）件数: {0}", reorderCount);

--- a/Sales Management App/Sales Management App/Form1.InventoryHistory.cs
+++ b/Sales Management App/Sales Management App/Form1.InventoryHistory.cs
@@ -67,6 +67,7 @@ namespace Sales_Management_App {
                 h.ResultStock,
                 h.Result
             }).ToList();
+            ApplyJapaneseHeaders(_inventoryHistoryGrid, InventoryHistoryGridHeaders);
         }
 
         private InventoryOperationType? GetSelectedHistoryOperationType() {

--- a/Sales Management App/Sales Management App/Form1.Products.cs
+++ b/Sales Management App/Sales Management App/Form1.Products.cs
@@ -73,6 +73,7 @@ namespace Sales_Management_App {
                 p.UnitPrice,
                 p.Category
             }).ToList();
+            ApplyJapaneseHeaders(_productsGrid, ProductGridHeaders);
         }
 
         private void SearchProducts(object sender, EventArgs e) {

--- a/Sales Management App/Sales Management App/Form1.Sales.cs
+++ b/Sales Management App/Sales Management App/Form1.Sales.cs
@@ -91,6 +91,7 @@ namespace Sales_Management_App {
                 s.Quantity,
                 s.SalesAmount
             }).ToList();
+            ApplyJapaneseHeaders(_salesGrid, SalesGridHeaders);
         }
 
         private void SearchSales(object sender, EventArgs e) {

--- a/Sales Management App/Sales Management App/Sales Management App.csproj
+++ b/Sales Management App/Sales Management App/Sales Management App.csproj
@@ -73,6 +73,9 @@
     <Compile Include="Form1.Common.cs">
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>
+    <Compile Include="Form1.GridHeaders.cs">
+      <DependentUpon>Form1.cs</DependentUpon>
+    </Compile>
     <Compile Include="Form1.Designer.cs">
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>


### PR DESCRIPTION
﻿## 概要
Issue #47 の対応として、各タブの一覧表ヘッダーを日本語表示に統一しました。

## 変更内容
- DataGridViewヘッダー適用の共通処理を追加
  - `Form1.GridHeaders.cs`
  - 列名 -> 日本語ヘッダーの対応表を集約（DRY）
- 対象一覧で日本語ヘッダーを適用
  - 商品一覧
  - 在庫一覧
  - 売上一覧
  - 商品別集計
  - 週次集計
- 併せて在庫履歴一覧にも日本語ヘッダーを適用

## 確認項目
- `dotnet build "Sales Management App/Sales Management App.slnx"` 成功
- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj` 成功（64件）

Closes #47
