### PR TITLE
feat: [27] WinForms再設計の基盤を整備する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,29 @@
 - 重複コードは放置せず、共通化・再利用でDRY原則を守る。
 - クラス内クラス（nested class）は禁止し、必要な型は独立した `.cs` ファイルへ切り出す。
 - 画面コードはUI責務に限定し、業務ロジック・データ変換はCore層/サービス層に配置する。
+
+## 15. WinForms再設計方針（MVC/MVP準拠）
+- 本プロジェクトのWinFormsは、`MainForm` をシェル（タブホスト）として最小責務にする。
+- `MainForm` は「画面コンテナ配置」と「依存オブジェクト配線」のみを担当し、業務処理は持たない。
+- 各機能タブは `UserControl` + `Controller`（MVP/Passive View相当）で分離する。
+  - View責務: 入力取得、表示更新、イベント通知
+  - Controller責務: 入力検証、Application/Core Service呼び出し、ViewModel変換、エラー制御
+- 画面表示用の整形データは必要に応じてViewModelを用意し、Domain Entityを直接UIへ露出させない。
+
+## 16. クラス配置ルール（Form1整理方針）
+- `Form1`（または `MainForm`）は原則 `Form1.cs` と `Form1.Designer.cs` を基本構成とし、巨大partialで機能分割しない。
+- タブ固有機能は `Form1.*.cs` へ追加せず、必ず独立 `.cs`（View/Controller/Model）へ切り出す。
+- コントロール宣言はDesigner管理を基本とし、動的生成が必要な場合は理由をコメントで明示する。
+- nested classは禁止。必要な型は独立ファイルへ定義する。
+
+## 17. 状態管理・データアクセス方針
+- アプリ全体状態は `AppState` に集約し、Form側で生の `List<T>` を分散保持しない。
+- 起動時ロードは `AppBootstrapper` へ集約し、Formの初期化コードから分離する。
+- CSV入出力は `AppDataRepository` 経由で扱い、UI層から `CsvDataStore` を直接呼ばない。
+- 永続化仕様（CSVヘッダー、保存先、互換性）は既存仕様を維持し、破壊的変更はIssueで合意後に実施する。
+
+## 18. 移行実装ルール（Issue #59 以降）
+- 移行は「基盤 -> MainFormシェル化 -> 共通基盤 -> 各タブ移行 -> 最終整理」の依存順で実施する。
+- 1 Issue = 1 ブランチ = 1 PR を厳守する。
+- 既存機能と等価動作を維持し、リファクタリングで挙動を変える場合は別Issue化する。
+- すべての移行タスクで build/test/主要手動シナリオ確認を実施する。

--- a/Sales Management App/Sales Management App/Form1.InitialLoad.cs
+++ b/Sales Management App/Sales Management App/Form1.InitialLoad.cs
@@ -1,47 +1,12 @@
 ﻿using System;
-using System.Globalization;
-using System.IO;
-using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using SalesManagementApp.Core.Application.Exceptions;
 
 namespace Sales_Management_App {
     public partial class Form1 {
-        private static readonly Regex SalesFileNamePattern =
-            new Regex(@"^sales_(\d{8})\.csv$", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
-
         private void LoadInitialDataFromRepositoryRoot() {
-            var rootPath = FindRepositoryRoot(AppDomain.CurrentDomain.BaseDirectory);
-            if (string.IsNullOrWhiteSpace(rootPath)) {
-                return;
-            }
-
             try {
-                var productsPath = Path.Combine(rootPath, "products.csv");
-                var inventoryPath = Path.Combine(rootPath, "inventory.csv");
-                var salesPath = ResolveSalesPath(rootPath);
-                var inventoryHistoryPath = Path.Combine(rootPath, "inventory_history.csv");
-                _inventoryHistoryPath = inventoryHistoryPath;
-
-                if (File.Exists(productsPath)) {
-                    _products.Clear();
-                    _products.AddRange(_csvDataStore.ReadProducts(productsPath));
-                }
-
-                if (File.Exists(inventoryPath)) {
-                    _inventories.Clear();
-                    _inventories.AddRange(_csvDataStore.ReadInventories(inventoryPath));
-                }
-
-                if (!string.IsNullOrWhiteSpace(salesPath) && File.Exists(salesPath)) {
-                    _sales.Clear();
-                    _sales.AddRange(_csvDataStore.ReadAndNormalizeSales(salesPath, _products));
-                }
-
-                if (File.Exists(inventoryHistoryPath)) {
-                    _inventoryHistories.Clear();
-                    _inventoryHistories.AddRange(_csvDataStore.ReadInventoryHistories(inventoryHistoryPath));
-                }
+                _appState = _appBootstrapper.LoadFromBaseDirectory(AppDomain.CurrentDomain.BaseDirectory);
 
                 RefreshProductsGrid();
                 RefreshInventoryGrid();
@@ -55,55 +20,6 @@ namespace Sales_Management_App {
             } catch (Exception ex) {
                 MessageBox.Show(string.Format("初期データの読み込み中にエラーが発生しました: {0}", ex.Message), "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
-        }
-
-        private static string FindRepositoryRoot(string baseDirectory) {
-            var current = new DirectoryInfo(baseDirectory);
-            var depth = 0;
-
-            while (current != null && depth < 10) {
-                if (File.Exists(Path.Combine(current.FullName, "AGENTS.md"))) {
-                    return current.FullName;
-                }
-
-                current = current.Parent;
-                depth++;
-            }
-
-            return string.Empty;
-        }
-
-        private static string ResolveSalesPath(string rootPath) {
-            var selectedPath = string.Empty;
-            var selectedDate = DateTime.MinValue;
-            var files = Directory.GetFiles(rootPath, "sales_*.csv");
-
-            foreach (var filePath in files) {
-                var fileName = Path.GetFileName(filePath);
-                var match = SalesFileNamePattern.Match(fileName);
-                if (!match.Success) {
-                    continue;
-                }
-
-                DateTime parsedDate;
-                if (!DateTime.TryParseExact(
-                    match.Groups[1].Value,
-                    "yyyyMMdd",
-                    CultureInfo.InvariantCulture,
-                    DateTimeStyles.None,
-                    out parsedDate)) {
-                    continue;
-                }
-
-                if (parsedDate <= selectedDate) {
-                    continue;
-                }
-
-                selectedDate = parsedDate;
-                selectedPath = filePath;
-            }
-
-            return selectedPath;
         }
     }
 }

--- a/Sales Management App/Sales Management App/Form1.InventoryHistory.cs
+++ b/Sales Management App/Sales Management App/Form1.InventoryHistory.cs
@@ -94,11 +94,7 @@ namespace Sales_Management_App {
         }
 
         private void PersistInventoryHistory() {
-            if (string.IsNullOrWhiteSpace(_inventoryHistoryPath)) {
-                return;
-            }
-
-            _csvDataStore.WriteInventoryHistories(_inventoryHistoryPath, _inventoryHistories);
+            _appDataRepository.WriteInventoryHistories(_inventoryHistoryPath, _inventoryHistories);
         }
     }
 }

--- a/Sales Management App/Sales Management App/Form1.cs
+++ b/Sales Management App/Sales Management App/Form1.cs
@@ -7,8 +7,8 @@ using System.Windows.Forms;
 using SalesManagementApp.Core.Application.Exceptions;
 using SalesManagementApp.Core.Application.Models;
 using SalesManagementApp.Core.Application.Services;
+using SalesManagementApp.Core.Application.State;
 using SalesManagementApp.Core.Domain.Entities;
-using SalesManagementApp.Core.Infrastructure.Csv;
 
 namespace Sales_Management_App {
     public partial class Form1 : Form {
@@ -17,13 +17,20 @@ namespace Sales_Management_App {
         private readonly InventoryHistoryService _inventoryHistoryService = new InventoryHistoryService();
         private readonly SalesService _salesService = new SalesService();
         private readonly SalesAggregationService _salesAggregationService = new SalesAggregationService();
-        private readonly CsvDataStore _csvDataStore = new CsvDataStore();
+        private readonly AppDataRepository _appDataRepository = new AppDataRepository();
+        private readonly AppBootstrapper _appBootstrapper = new AppBootstrapper();
 
-        private readonly List<Product> _products = new List<Product>();
-        private readonly List<InventoryRecord> _inventories = new List<InventoryRecord>();
-        private readonly List<InventoryHistoryRecord> _inventoryHistories = new List<InventoryHistoryRecord>();
-        private readonly List<SaleRecord> _sales = new List<SaleRecord>();
-        private string _inventoryHistoryPath = string.Empty;
+        private AppState _appState = new AppState();
+
+        private List<Product> _products { get { return _appState.Products; } }
+
+        private List<InventoryRecord> _inventories { get { return _appState.Inventories; } }
+
+        private List<InventoryHistoryRecord> _inventoryHistories { get { return _appState.InventoryHistories; } }
+
+        private List<SaleRecord> _sales { get { return _appState.Sales; } }
+
+        private string _inventoryHistoryPath { get { return _appState.InventoryHistoryPath; } }
 
         private DataGridView _productsGrid;
         private TextBox _productIdText;

--- a/src/SalesManagementApp.Core/Application/State/AppBootstrapper.cs
+++ b/src/SalesManagementApp.Core/Application/State/AppBootstrapper.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace SalesManagementApp.Core.Application.State;
+
+public class AppBootstrapper
+{
+    private static readonly Regex SalesFileNamePattern =
+        new(@"^sales_(\d{8})\.csv$", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private readonly AppDataRepository _repository;
+
+    public AppBootstrapper()
+        : this(new AppDataRepository())
+    {
+    }
+
+    internal AppBootstrapper(AppDataRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public AppState LoadFromBaseDirectory(string baseDirectory)
+    {
+        var rootPath = FindRepositoryRoot(baseDirectory);
+        if (string.IsNullOrWhiteSpace(rootPath))
+        {
+            return new AppState();
+        }
+
+        var state = new AppState
+        {
+            RepositoryRootPath = rootPath,
+            ProductsPath = Path.Combine(rootPath, "products.csv"),
+            InventoryPath = Path.Combine(rootPath, "inventory.csv"),
+            InventoryHistoryPath = Path.Combine(rootPath, "inventory_history.csv")
+        };
+        state.SalesPath = ResolveSalesPath(rootPath);
+
+        state.Products.AddRange(_repository.ReadProductsIfExists(state.ProductsPath));
+        state.Inventories.AddRange(_repository.ReadInventoriesIfExists(state.InventoryPath));
+        state.Sales.AddRange(_repository.ReadAndNormalizeSalesIfExists(state.SalesPath, state.Products));
+        state.InventoryHistories.AddRange(_repository.ReadInventoryHistoriesIfExists(state.InventoryHistoryPath));
+
+        return state;
+    }
+
+    private static string FindRepositoryRoot(string baseDirectory)
+    {
+        var current = new DirectoryInfo(baseDirectory);
+        var depth = 0;
+
+        while (current is not null && depth < 10)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "AGENTS.md")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+            depth++;
+        }
+
+        return string.Empty;
+    }
+
+    private static string ResolveSalesPath(string rootPath)
+    {
+        var selectedPath = string.Empty;
+        var selectedDate = DateTime.MinValue;
+        var files = Directory.GetFiles(rootPath, "sales_*.csv");
+
+        foreach (var filePath in files)
+        {
+            var fileName = Path.GetFileName(filePath);
+            var match = SalesFileNamePattern.Match(fileName);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            if (!DateTime.TryParseExact(
+                    match.Groups[1].Value,
+                    "yyyyMMdd",
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var parsedDate))
+            {
+                continue;
+            }
+
+            if (parsedDate <= selectedDate)
+            {
+                continue;
+            }
+
+            selectedDate = parsedDate;
+            selectedPath = filePath;
+        }
+
+        return selectedPath;
+    }
+}

--- a/src/SalesManagementApp.Core/Application/State/AppDataRepository.cs
+++ b/src/SalesManagementApp.Core/Application/State/AppDataRepository.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using SalesManagementApp.Core.Domain.Entities;
+using SalesManagementApp.Core.Infrastructure.Csv;
+
+namespace SalesManagementApp.Core.Application.State;
+
+public class AppDataRepository
+{
+    private readonly CsvDataStore _csvDataStore;
+
+    public AppDataRepository()
+        : this(new CsvDataStore())
+    {
+    }
+
+    internal AppDataRepository(CsvDataStore csvDataStore)
+    {
+        _csvDataStore = csvDataStore ?? throw new ArgumentNullException(nameof(csvDataStore));
+    }
+
+    public IReadOnlyList<Product> ReadProductsIfExists(string filePath)
+    {
+        return File.Exists(filePath) ? _csvDataStore.ReadProducts(filePath) : Array.Empty<Product>();
+    }
+
+    public IReadOnlyList<InventoryRecord> ReadInventoriesIfExists(string filePath)
+    {
+        return File.Exists(filePath) ? _csvDataStore.ReadInventories(filePath) : Array.Empty<InventoryRecord>();
+    }
+
+    public IReadOnlyList<SaleRecord> ReadAndNormalizeSalesIfExists(string filePath, IReadOnlyCollection<Product> products)
+    {
+        return File.Exists(filePath) ? _csvDataStore.ReadAndNormalizeSales(filePath, products) : Array.Empty<SaleRecord>();
+    }
+
+    public IReadOnlyList<InventoryHistoryRecord> ReadInventoryHistoriesIfExists(string filePath)
+    {
+        return File.Exists(filePath) ? _csvDataStore.ReadInventoryHistories(filePath) : Array.Empty<InventoryHistoryRecord>();
+    }
+
+    public void WriteInventoryHistories(string filePath, IEnumerable<InventoryHistoryRecord> records)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            return;
+        }
+
+        _csvDataStore.WriteInventoryHistories(filePath, records);
+    }
+}

--- a/src/SalesManagementApp.Core/Application/State/AppState.cs
+++ b/src/SalesManagementApp.Core/Application/State/AppState.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using SalesManagementApp.Core.Domain.Entities;
+
+namespace SalesManagementApp.Core.Application.State;
+
+public sealed class AppState
+{
+    public List<Product> Products { get; set; } = new();
+
+    public List<InventoryRecord> Inventories { get; set; } = new();
+
+    public List<InventoryHistoryRecord> InventoryHistories { get; set; } = new();
+
+    public List<SaleRecord> Sales { get; set; } = new();
+
+    public string RepositoryRootPath { get; set; } = string.Empty;
+
+    public string ProductsPath { get; set; } = string.Empty;
+
+    public string InventoryPath { get; set; } = string.Empty;
+
+    public string SalesPath { get; set; } = string.Empty;
+
+    public string InventoryHistoryPath { get; set; } = string.Empty;
+}

--- a/tests/SalesManagementApp.Tests/AppState/AppBootstrapperTests.cs
+++ b/tests/SalesManagementApp.Tests/AppState/AppBootstrapperTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using SalesManagementApp.Core.Application.State;
+
+namespace SalesManagementApp.Tests.AppState;
+
+public class AppBootstrapperTests
+{
+    private string _workDir = string.Empty;
+    private AppBootstrapper _bootstrapper = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), "SalesManagementApp.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_workDir);
+        _bootstrapper = new AppBootstrapper();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_workDir))
+        {
+            Directory.Delete(_workDir, true);
+        }
+    }
+
+    [Test]
+    public void LoadFromBaseDirectory_WhenRepositoryRootExists_LoadsStateAndResolvesLatestSalesFile()
+    {
+        var root = Path.Combine(_workDir, "repo");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "AGENTS.md"), "marker");
+        File.WriteAllLines(Path.Combine(root, "products.csv"), new[]
+        {
+            "ProductId,ProductName,UnitPrice,Category",
+            "P001,Cola,120,Drink"
+        });
+        File.WriteAllLines(Path.Combine(root, "inventory.csv"), new[]
+        {
+            "StoreId,ProductId,Stock",
+            "S001,P001,10"
+        });
+        File.WriteAllLines(Path.Combine(root, "sales_20260301.csv"), new[]
+        {
+            "SaleDate,StoreId,ProductId,Quantity,SalesAmount",
+            "2026-03-01,S001,P001,1,120"
+        });
+        File.WriteAllLines(Path.Combine(root, "sales_20260302.csv"), new[]
+        {
+            "SaleDate,StoreId,ProductId,Quantity,SalesAmount",
+            "2026-03-02,S001,P001,2,240"
+        });
+        File.WriteAllLines(Path.Combine(root, "inventory_history.csv"), new[]
+        {
+            "OccurredAt,OperationType,StoreId,ProductId,Quantity,ResultStock,Result",
+            "2026-03-02 09:00:00,Sale,S001,P001,2,8,Success"
+        });
+
+        var nestedBase = Path.Combine(root, "Sales Management App", "Sales Management App", "bin", "Debug");
+        Directory.CreateDirectory(nestedBase);
+
+        var state = _bootstrapper.LoadFromBaseDirectory(nestedBase);
+
+        Assert.That(state.RepositoryRootPath, Is.EqualTo(root));
+        Assert.That(state.Products.Count, Is.EqualTo(1));
+        Assert.That(state.Inventories.Count, Is.EqualTo(1));
+        Assert.That(state.Sales.Count, Is.EqualTo(1));
+        Assert.That(state.Sales[0].SaleDate, Is.EqualTo(new DateTime(2026, 3, 2)));
+        Assert.That(state.InventoryHistories.Count, Is.EqualTo(1));
+        Assert.That(state.SalesPath, Does.EndWith("sales_20260302.csv"));
+    }
+
+    [Test]
+    public void LoadFromBaseDirectory_WhenRepositoryRootNotFound_ReturnsEmptyState()
+    {
+        var baseDir = Path.Combine(_workDir, "standalone");
+        Directory.CreateDirectory(baseDir);
+
+        var state = _bootstrapper.LoadFromBaseDirectory(baseDir);
+
+        Assert.That(state.RepositoryRootPath, Is.Empty);
+        Assert.That(state.Products, Is.Empty);
+        Assert.That(state.Inventories, Is.Empty);
+        Assert.That(state.Sales, Is.Empty);
+        Assert.That(state.InventoryHistories, Is.Empty);
+    }
+}

--- a/tests/SalesManagementApp.Tests/AppState/AppDataRepositoryTests.cs
+++ b/tests/SalesManagementApp.Tests/AppState/AppDataRepositoryTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using SalesManagementApp.Core.Application.State;
+using SalesManagementApp.Core.Domain.Entities;
+using SalesManagementApp.Core.Infrastructure.Csv;
+using ProductEntity = SalesManagementApp.Core.Domain.Entities.Product;
+
+namespace SalesManagementApp.Tests.AppState;
+
+public class AppDataRepositoryTests
+{
+    private string _workDir = string.Empty;
+    private AppDataRepository _repository = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(), "SalesManagementApp.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_workDir);
+        _repository = new AppDataRepository();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_workDir))
+        {
+            Directory.Delete(_workDir, true);
+        }
+    }
+
+    [Test]
+    public void ReadProductsIfExists_WhenFileDoesNotExist_ReturnsEmpty()
+    {
+        var path = Path.Combine(_workDir, "products.csv");
+
+        var result = _repository.ReadProductsIfExists(path);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void ReadAndNormalizeSalesIfExists_WhenLegacyHeader_ReturnsSalesAndNormalizesCsv()
+    {
+        var path = Path.Combine(_workDir, "sales.csv");
+        File.WriteAllLines(path, new[]
+        {
+            "SaleDate,StoreId,ProductId,Quantity",
+            "2026-03-03,S001,P001,2"
+        });
+        var products = new[]
+        {
+            new ProductEntity { ProductId = "P001", ProductName = "Cola", UnitPrice = 120, Category = "Drink" }
+        };
+
+        var result = _repository.ReadAndNormalizeSalesIfExists(path, products);
+
+        Assert.That(result.Count, Is.EqualTo(1));
+        Assert.That(result[0].SalesAmount, Is.EqualTo(240));
+        var lines = File.ReadAllLines(path);
+        Assert.That(lines[0], Is.EqualTo("SaleDate,StoreId,ProductId,Quantity,SalesAmount"));
+    }
+
+    [Test]
+    public void WriteInventoryHistories_WhenPathIsProvided_WritesCsv()
+    {
+        var path = Path.Combine(_workDir, "inventory_history.csv");
+        var records = new[]
+        {
+            new InventoryHistoryRecord
+            {
+                OccurredAt = new DateTime(2026, 3, 3, 8, 0, 0),
+                OperationType = InventoryOperationType.Inbound,
+                StoreId = "S001",
+                ProductId = "P001",
+                Quantity = 3,
+                ResultStock = 13,
+                Result = "Success"
+            }
+        };
+
+        _repository.WriteInventoryHistories(path, records);
+
+        var reloaded = new CsvDataStore().ReadInventoryHistories(path);
+        Assert.That(reloaded.Count, Is.EqualTo(1));
+        Assert.That(reloaded[0].OperationType, Is.EqualTo(InventoryOperationType.Inbound));
+        Assert.That(reloaded[0].ResultStock, Is.EqualTo(13));
+    }
+}


### PR DESCRIPTION
﻿## 概要
Issue #59 の対応として、WinForms再設計の基盤（AppState/Bootstrapper/Repository）を導入しました。

## 変更内容
- 設計方針を `AGENTS.md` に追記
  - MainFormシェル化
  - UserControl + Controller分割
  - AppState/Bootstrapper/Repository方針
- Coreに再設計基盤を追加
  - `AppState`
  - `AppDataRepository`
  - `AppBootstrapper`
- `Form1` の初期読込を `AppBootstrapper` 経由へ置換
- 在庫履歴の保存を `AppDataRepository` 経由へ置換
- NUnitテストを追加
  - `AppBootstrapperTests`
  - `AppDataRepositoryTests`

## 確認項目
- `dotnet build "Sales Management App/Sales Management App.slnx"` 成功
- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj` 成功（69件）

Closes #59
