### PR TITLE
refactor: [28] MainFormをシェル化する

### DIFF
--- a/Sales Management App/Sales Management App/Form1.InitialLoad.cs
+++ b/Sales Management App/Sales Management App/Form1.InitialLoad.cs
@@ -7,14 +7,6 @@ namespace Sales_Management_App {
         private void LoadInitialDataFromRepositoryRoot() {
             try {
                 _appState = _appBootstrapper.LoadFromBaseDirectory(AppDomain.CurrentDomain.BaseDirectory);
-
-                RefreshProductsGrid();
-                RefreshInventoryGrid();
-                RefreshInventoryHistoryGrid();
-                RefreshSaleProductOptions();
-                RefreshSalesGrid();
-                ResetAggregationDisplay();
-                UpdateSaleUnitPriceAndAmountPreview();
             } catch (DomainValidationException ex) {
                 MessageBox.Show(string.Format("初期データの読み込みに失敗しました: {0}", ex.Message), "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             } catch (Exception ex) {

--- a/Sales Management App/Sales Management App/Form1.cs
+++ b/Sales Management App/Sales Management App/Form1.cs
@@ -1,24 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
-using SalesManagementApp.Core.Application.Exceptions;
-using SalesManagementApp.Core.Application.Models;
 using SalesManagementApp.Core.Application.Services;
 using SalesManagementApp.Core.Application.State;
 using SalesManagementApp.Core.Domain.Entities;
 
 namespace Sales_Management_App {
     public partial class Form1 : Form {
-        private readonly ProductService _productService = new ProductService();
-        private readonly InventoryService _inventoryService = new InventoryService();
-        private readonly InventoryHistoryService _inventoryHistoryService = new InventoryHistoryService();
-        private readonly SalesService _salesService = new SalesService();
-        private readonly SalesAggregationService _salesAggregationService = new SalesAggregationService();
-        private readonly AppDataRepository _appDataRepository = new AppDataRepository();
-        private readonly AppBootstrapper _appBootstrapper = new AppBootstrapper();
+        private readonly ProductService _productService;
+        private readonly InventoryService _inventoryService;
+        private readonly InventoryHistoryService _inventoryHistoryService;
+        private readonly SalesService _salesService;
+        private readonly SalesAggregationService _salesAggregationService;
+        private readonly AppDataRepository _appDataRepository;
+        private readonly AppBootstrapper _appBootstrapper;
 
         private AppState _appState = new AppState();
 
@@ -77,13 +72,40 @@ namespace Sales_Management_App {
 
         private ErrorProvider _errorProvider;
 
-        public Form1() {
-            InitializeComponent();
-            InitializeMainTabs();
-            LoadInitialDataFromRepositoryRoot();
+        public Form1()
+            : this(MainFormDependencies.CreateDefault()) {
         }
 
-        private void InitializeMainTabs() {
+        internal Form1(MainFormDependencies dependencies) {
+            if (dependencies == null) {
+                throw new ArgumentNullException("dependencies");
+            }
+
+            _productService = dependencies.ProductService;
+            _inventoryService = dependencies.InventoryService;
+            _inventoryHistoryService = dependencies.InventoryHistoryService;
+            _salesService = dependencies.SalesService;
+            _salesAggregationService = dependencies.SalesAggregationService;
+            _appDataRepository = dependencies.AppDataRepository;
+            _appBootstrapper = dependencies.AppBootstrapper;
+
+            InitializeComponent();
+            InitializeShell();
+            LoadInitialDataFromRepositoryRoot();
+            InitializeViewsFromState();
+        }
+
+        private void InitializeViewsFromState() {
+            RefreshProductsGrid();
+            RefreshInventoryGrid();
+            RefreshInventoryHistoryGrid();
+            RefreshSaleProductOptions();
+            RefreshSalesGrid();
+            ResetAggregationDisplay();
+            UpdateSaleUnitPriceAndAmountPreview();
+        }
+
+        private void InitializeShell() {
             Text = "Sales Management App";
             Width = 1100;
             Height = 700;
@@ -102,13 +124,6 @@ namespace Sales_Management_App {
             Controls.Add(tabs);
 
             WireSalesInputValidation();
-            RefreshProductsGrid();
-            RefreshInventoryGrid();
-            RefreshInventoryHistoryGrid();
-            RefreshSaleProductOptions();
-            RefreshSalesGrid();
-            ResetAggregationDisplay();
-            UpdateSaleUnitPriceAndAmountPreview();
         }
 
     }

--- a/Sales Management App/Sales Management App/MainFormDependencies.cs
+++ b/Sales Management App/Sales Management App/MainFormDependencies.cs
@@ -1,0 +1,49 @@
+using System;
+using SalesManagementApp.Core.Application.Services;
+using SalesManagementApp.Core.Application.State;
+
+namespace Sales_Management_App {
+    internal sealed class MainFormDependencies {
+        internal ProductService ProductService { get; private set; }
+
+        internal InventoryService InventoryService { get; private set; }
+
+        internal InventoryHistoryService InventoryHistoryService { get; private set; }
+
+        internal SalesService SalesService { get; private set; }
+
+        internal SalesAggregationService SalesAggregationService { get; private set; }
+
+        internal AppDataRepository AppDataRepository { get; private set; }
+
+        internal AppBootstrapper AppBootstrapper { get; private set; }
+
+        internal static MainFormDependencies CreateDefault() {
+            return new MainFormDependencies(
+                new ProductService(),
+                new InventoryService(),
+                new InventoryHistoryService(),
+                new SalesService(),
+                new SalesAggregationService(),
+                new AppDataRepository(),
+                new AppBootstrapper());
+        }
+
+        private MainFormDependencies(
+            ProductService productService,
+            InventoryService inventoryService,
+            InventoryHistoryService inventoryHistoryService,
+            SalesService salesService,
+            SalesAggregationService salesAggregationService,
+            AppDataRepository appDataRepository,
+            AppBootstrapper appBootstrapper) {
+            ProductService = productService ?? throw new ArgumentNullException("productService");
+            InventoryService = inventoryService ?? throw new ArgumentNullException("inventoryService");
+            InventoryHistoryService = inventoryHistoryService ?? throw new ArgumentNullException("inventoryHistoryService");
+            SalesService = salesService ?? throw new ArgumentNullException("salesService");
+            SalesAggregationService = salesAggregationService ?? throw new ArgumentNullException("salesAggregationService");
+            AppDataRepository = appDataRepository ?? throw new ArgumentNullException("appDataRepository");
+            AppBootstrapper = appBootstrapper ?? throw new ArgumentNullException("appBootstrapper");
+        }
+    }
+}

--- a/Sales Management App/Sales Management App/Program.cs
+++ b/Sales Management App/Sales Management App/Program.cs
@@ -13,7 +13,8 @@ namespace Sales_Management_App {
         static void Main() {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new Form1());
+            var dependencies = MainFormDependencies.CreateDefault();
+            Application.Run(new Form1(dependencies));
         }
     }
 }

--- a/Sales Management App/Sales Management App/Sales Management App.csproj
+++ b/Sales Management App/Sales Management App/Sales Management App.csproj
@@ -82,6 +82,7 @@
     <Compile Include="SaleProductOption.cs" />
     <Compile Include="InventoryHistoryOperationFilterOption.cs" />
     <Compile Include="AggregationSnapshot.cs" />
+    <Compile Include="MainFormDependencies.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">


### PR DESCRIPTION
﻿## 概要
Issue #60 の対応として、MainForm（現 `Form1`）のシェル化を進めました。

## 変更内容
- 依存オブジェクトの組み立てを `MainFormDependencies` に集約
- `Program.cs` で依存を構築し `Form1` に注入
- `Form1` に依存注入コンストラクタを追加
- 初期化順を明確化
  - `InitializeShell()`
  - `LoadInitialDataFromRepositoryRoot()`
  - `InitializeViewsFromState()`
- シェル初期化とデータ反映初期化を分離し、責務境界を整理

## 確認項目
- `dotnet build "Sales Management App/Sales Management App.slnx"` 成功
- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj` 成功（69件）

Closes #60
