### PR TITLE
refactor: [29] プレゼンテーション共通基盤を導入する

### DIFF
--- a/Sales Management App/Sales Management App/Form1.Aggregation.cs
+++ b/Sales Management App/Sales Management App/Form1.Aggregation.cs
@@ -18,7 +18,7 @@ namespace Sales_Management_App {
                 var snapshot = BuildAggregationSnapshot();
                 RenderAggregationSnapshot(snapshot);
                 Clipboard.SetText(BuildAggregationClipboardText(snapshot));
-                MessageBox.Show("集計結果をクリップボードにコピーしました。", "完了", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                _messageService.ShowInfo("集計結果をクリップボードにコピーしました。");
             });
         }
 

--- a/Sales Management App/Sales Management App/Form1.Common.cs
+++ b/Sales Management App/Sales Management App/Form1.Common.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Windows.Forms;
-using SalesManagementApp.Core.Application.Exceptions;
 
 namespace Sales_Management_App {
     public partial class Form1 {
@@ -8,14 +6,8 @@ namespace Sales_Management_App {
             return value == null ? string.Empty : value.ToString();
         }
 
-        private static void ExecuteWithValidation(Action action) {
-            try {
-                action.Invoke();
-            } catch (DomainValidationException ex) {
-                MessageBox.Show(ex.Message, "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-            } catch (Exception ex) {
-                MessageBox.Show(string.Format("予期しないエラーが発生しました: {0}", ex.Message), "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
+        private void ExecuteWithValidation(Action action) {
+            _uiActionExecutor.Execute(action);
         }
 
         private void ClearProductInputs() {

--- a/Sales Management App/Sales Management App/Form1.GridHeaders.cs
+++ b/Sales Management App/Sales Management App/Form1.GridHeaders.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Windows.Forms;
+using Sales_Management_App.Presentation.Common;
 
 namespace Sales_Management_App {
     public partial class Form1 {
@@ -54,16 +55,7 @@ namespace Sales_Management_App {
             };
 
         private static void ApplyJapaneseHeaders(DataGridView grid, IReadOnlyDictionary<string, string> headers) {
-            if (grid == null || headers == null) {
-                return;
-            }
-
-            foreach (DataGridViewColumn column in grid.Columns) {
-                string text;
-                if (headers.TryGetValue(column.Name, out text)) {
-                    column.HeaderText = text;
-                }
-            }
+            DataGridHeaderMapper.Apply(grid, headers);
         }
     }
 }

--- a/Sales Management App/Sales Management App/Form1.InitialLoad.cs
+++ b/Sales Management App/Sales Management App/Form1.InitialLoad.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Windows.Forms;
 using SalesManagementApp.Core.Application.Exceptions;
 
 namespace Sales_Management_App {
@@ -8,9 +7,9 @@ namespace Sales_Management_App {
             try {
                 _appState = _appBootstrapper.LoadFromBaseDirectory(AppDomain.CurrentDomain.BaseDirectory);
             } catch (DomainValidationException ex) {
-                MessageBox.Show(string.Format("初期データの読み込みに失敗しました: {0}", ex.Message), "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                _messageService.ShowWarning(string.Format("初期データの読み込みに失敗しました: {0}", ex.Message), "入力エラー");
             } catch (Exception ex) {
-                MessageBox.Show(string.Format("初期データの読み込み中にエラーが発生しました: {0}", ex.Message), "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                _messageService.ShowError(ex);
             }
         }
     }

--- a/Sales Management App/Sales Management App/Form1.Inventory.cs
+++ b/Sales Management App/Sales Management App/Form1.Inventory.cs
@@ -14,7 +14,7 @@ namespace Sales_Management_App {
                 RefreshInventoryGrid();
                 RefreshInventoryHistoryGrid();
                 ClearInventoryInputs();
-                MessageBox.Show("入荷を反映しました。", "完了", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                _messageService.ShowInfo("入荷を反映しました。");
             });
         }
 
@@ -26,7 +26,7 @@ namespace Sales_Management_App {
                 RefreshInventoryGrid();
                 RefreshInventoryHistoryGrid();
                 ClearInventoryInputs();
-                MessageBox.Show("出庫を反映しました。", "完了", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                _messageService.ShowInfo("出庫を反映しました。");
             });
         }
 

--- a/Sales Management App/Sales Management App/Form1.Products.cs
+++ b/Sales Management App/Sales Management App/Form1.Products.cs
@@ -28,11 +28,11 @@ namespace Sales_Management_App {
         private void DeleteProduct(object sender, EventArgs e) {
             var id = _productIdText.Text.Trim();
             if (string.IsNullOrWhiteSpace(id)) {
-                MessageBox.Show("削除対象の商品IDを選択してください。", "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                _messageService.ShowWarning("削除対象の商品IDを選択してください。", "入力エラー");
                 return;
             }
 
-            if (MessageBox.Show(string.Format("商品ID={0} を削除します。よろしいですか？", id), "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes) {
+            if (_messageService.Confirm(string.Format("商品ID={0} を削除します。よろしいですか？", id), "確認") != DialogResult.Yes) {
                 return;
             }
 

--- a/Sales Management App/Sales Management App/Form1.Sales.cs
+++ b/Sales Management App/Sales Management App/Form1.Sales.cs
@@ -19,7 +19,7 @@ namespace Sales_Management_App {
                 RefreshInventoryGrid();
                 RefreshInventoryHistoryGrid();
                 ClearSaleInputs();
-                MessageBox.Show(string.Format("売上を登録しました。金額: {0} 円", registered.SalesAmount), "完了", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                _messageService.ShowInfo(string.Format("売上を登録しました。金額: {0} 円", registered.SalesAmount));
             });
         }
 
@@ -152,7 +152,7 @@ namespace Sales_Management_App {
             }
 
             if (!valid && showMessage) {
-                MessageBox.Show("入力内容を確認してください。", "入力エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                _messageService.ShowWarning("入力内容を確認してください。", "入力エラー");
             }
 
             return valid;

--- a/Sales Management App/Sales Management App/Form1.cs
+++ b/Sales Management App/Sales Management App/Form1.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using SalesManagementApp.Core.Application.Services;
 using SalesManagementApp.Core.Application.State;
 using SalesManagementApp.Core.Domain.Entities;
+using Sales_Management_App.Presentation.Common;
 
 namespace Sales_Management_App {
     public partial class Form1 : Form {
@@ -14,6 +15,8 @@ namespace Sales_Management_App {
         private readonly SalesAggregationService _salesAggregationService;
         private readonly AppDataRepository _appDataRepository;
         private readonly AppBootstrapper _appBootstrapper;
+        private readonly UiMessageService _messageService;
+        private readonly UiActionExecutor _uiActionExecutor;
 
         private AppState _appState = new AppState();
 
@@ -88,6 +91,8 @@ namespace Sales_Management_App {
             _salesAggregationService = dependencies.SalesAggregationService;
             _appDataRepository = dependencies.AppDataRepository;
             _appBootstrapper = dependencies.AppBootstrapper;
+            _messageService = new UiMessageService();
+            _uiActionExecutor = new UiActionExecutor(_messageService);
 
             InitializeComponent();
             InitializeShell();

--- a/Sales Management App/Sales Management App/Presentation/Common/DataGridHeaderMapper.cs
+++ b/Sales Management App/Sales Management App/Presentation/Common/DataGridHeaderMapper.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace Sales_Management_App.Presentation.Common {
+    internal static class DataGridHeaderMapper {
+        internal static void Apply(DataGridView grid, IReadOnlyDictionary<string, string> headers) {
+            if (grid == null || headers == null) {
+                return;
+            }
+
+            foreach (DataGridViewColumn column in grid.Columns) {
+                string mapped;
+                if (headers.TryGetValue(column.Name, out mapped)) {
+                    column.HeaderText = mapped;
+                }
+            }
+        }
+    }
+}

--- a/Sales Management App/Sales Management App/Presentation/Common/UiActionExecutor.cs
+++ b/Sales Management App/Sales Management App/Presentation/Common/UiActionExecutor.cs
@@ -1,0 +1,22 @@
+using System;
+using SalesManagementApp.Core.Application.Exceptions;
+
+namespace Sales_Management_App.Presentation.Common {
+    internal sealed class UiActionExecutor {
+        private readonly UiMessageService _messageService;
+
+        internal UiActionExecutor(UiMessageService messageService) {
+            _messageService = messageService ?? throw new ArgumentNullException("messageService");
+        }
+
+        internal void Execute(Action action) {
+            try {
+                action.Invoke();
+            } catch (DomainValidationException ex) {
+                _messageService.ShowWarning(ex.Message, "入力エラー");
+            } catch (Exception ex) {
+                _messageService.ShowError(ex);
+            }
+        }
+    }
+}

--- a/Sales Management App/Sales Management App/Presentation/Common/UiMessageService.cs
+++ b/Sales Management App/Sales Management App/Presentation/Common/UiMessageService.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Windows.Forms;
+
+namespace Sales_Management_App.Presentation.Common {
+    internal sealed class UiMessageService {
+        internal void ShowInfo(string message, string title = "完了") {
+            MessageBox.Show(message, title, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        internal void ShowWarning(string message, string title = "入力エラー") {
+            MessageBox.Show(message, title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        }
+
+        internal void ShowError(Exception ex) {
+            MessageBox.Show(string.Format("予期しないエラーが発生しました: {0}", ex.Message), "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+
+        internal DialogResult Confirm(string message, string title = "確認") {
+            return MessageBox.Show(message, title, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+        }
+    }
+}

--- a/Sales Management App/Sales Management App/Sales Management App.csproj
+++ b/Sales Management App/Sales Management App/Sales Management App.csproj
@@ -83,6 +83,9 @@
     <Compile Include="InventoryHistoryOperationFilterOption.cs" />
     <Compile Include="AggregationSnapshot.cs" />
     <Compile Include="MainFormDependencies.cs" />
+    <Compile Include="Presentation\Common\DataGridHeaderMapper.cs" />
+    <Compile Include="Presentation\Common\UiActionExecutor.cs" />
+    <Compile Include="Presentation\Common\UiMessageService.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/docs/presentation-common-guidelines.md
+++ b/docs/presentation-common-guidelines.md
@@ -1,0 +1,19 @@
+# Presentation Common Guidelines
+
+## Purpose
+- Keep WinForms View code thin and avoid duplicated UI logic.
+- Reuse common utilities for error handling, information messages, and grid header mapping.
+
+## Common Components
+- `Presentation/Common/UiMessageService.cs`
+  - Show info/warning/error dialogs and confirmation prompts.
+- `Presentation/Common/UiActionExecutor.cs`
+  - Wrap UI actions with standardized exception handling.
+- `Presentation/Common/DataGridHeaderMapper.cs`
+  - Apply Japanese headers to `DataGridView` columns.
+
+## Usage Rules
+- Do not call `MessageBox.Show` directly in tab implementations. Use `UiMessageService`.
+- Execute event-driven operations through `UiActionExecutor.Execute`.
+- For list grid headers, define mapping dictionaries in the View and apply via `DataGridHeaderMapper`.
+- Keep business decisions in Service/Controller classes and leave View code for input/output.


### PR DESCRIPTION
﻿## 概要
Issue #61 の対応として、プレゼンテーション層の共通基盤を導入しました。

## 変更内容
- 共通UIクラスを追加
  - `Presentation/Common/UiMessageService.cs`
  - `Presentation/Common/UiActionExecutor.cs`
  - `Presentation/Common/DataGridHeaderMapper.cs`
- `Form1` の共通処理を置換
  - `ExecuteWithValidation` は `UiActionExecutor` 経由へ変更
  - 各タブの直接 `MessageBox.Show` を `UiMessageService` 経由へ変更
  - ヘッダー適用は `DataGridHeaderMapper` 経由へ変更
- 利用ガイドを追加
  - `docs/presentation-common-guidelines.md`

## 確認項目
- `dotnet build "Sales Management App/Sales Management App.slnx"` 成功
- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj` 成功（69件）

Closes #61
