### PR TITLE
refactor: [38] 可読性向上と書式統一の改善

### DIFF
--- a/Sales Management App/Sales Management App/Presentation/Tabs/Inventory/InventoryView.cs
+++ b/Sales Management App/Sales Management App/Presentation/Tabs/Inventory/InventoryView.cs
@@ -134,21 +134,25 @@ namespace Sales_Management_App.Presentation.Tabs.Inventory {
             }
 
             var row = _grid.SelectedRows[0];
-            var stockText = row.Cells["Stock"].Value == null ? "0" : row.Cells["Stock"].Value.ToString();
-            int stock;
-            int.TryParse(stockText, out stock);
 
             return new InventoryViewRow {
                 StoreId = ToText(row.Cells["StoreId"].Value),
                 ProductId = ToText(row.Cells["ProductId"].Value),
-                Stock = stock
+                Stock = ToInt32(row.Cells["Stock"].Value)
             };
         }
 
         internal void SetInput(InventoryInputModel input) {
-            _storeIdText.Text = input == null ? string.Empty : input.StoreId;
-            _productIdText.Text = input == null ? string.Empty : input.ProductId;
-            _quantityText.Text = input == null ? string.Empty : input.QuantityText;
+            if (input == null) {
+                _storeIdText.Text = string.Empty;
+                _productIdText.Text = string.Empty;
+                _quantityText.Text = string.Empty;
+                return;
+            }
+
+            _storeIdText.Text = input.StoreId;
+            _productIdText.Text = input.ProductId;
+            _quantityText.Text = input.QuantityText;
         }
 
         internal void ClearInput() {
@@ -173,7 +177,12 @@ namespace Sales_Management_App.Presentation.Tabs.Inventory {
         }
 
         private static string ToText(object value) {
-            return value == null ? string.Empty : value.ToString();
+            return value?.ToString() ?? string.Empty;
+        }
+
+        private static int ToInt32(object value) {
+            int parsed;
+            return int.TryParse(ToText(value), out parsed) ? parsed : 0;
         }
 
         private static TextBox AddLabeledTextBox(TableLayoutPanel panel, string label, int col, int row) {

--- a/Sales Management App/Sales Management App/Presentation/Tabs/Products/ProductsView.cs
+++ b/Sales Management App/Sales Management App/Presentation/Tabs/Products/ProductsView.cs
@@ -138,23 +138,28 @@ namespace Sales_Management_App.Presentation.Tabs.Products {
             }
 
             var row = _grid.SelectedRows[0];
-            var unitPriceText = row.Cells["UnitPrice"].Value == null ? "0" : row.Cells["UnitPrice"].Value.ToString();
-            int unitPrice;
-            int.TryParse(unitPriceText, out unitPrice);
 
             return new ProductViewRow {
                 ProductId = ToText(row.Cells["ProductId"].Value),
                 ProductName = ToText(row.Cells["ProductName"].Value),
-                UnitPrice = unitPrice,
+                UnitPrice = ToInt32(row.Cells["UnitPrice"].Value),
                 Category = ToText(row.Cells["Category"].Value)
             };
         }
 
         internal void SetInput(ProductInputModel input) {
-            _productIdText.Text = input == null ? string.Empty : input.ProductId;
-            _productNameText.Text = input == null ? string.Empty : input.ProductName;
-            _unitPriceText.Text = input == null ? string.Empty : input.UnitPriceText;
-            _categoryText.Text = input == null ? string.Empty : input.Category;
+            if (input == null) {
+                _productIdText.Text = string.Empty;
+                _productNameText.Text = string.Empty;
+                _unitPriceText.Text = string.Empty;
+                _categoryText.Text = string.Empty;
+                return;
+            }
+
+            _productIdText.Text = input.ProductId;
+            _productNameText.Text = input.ProductName;
+            _unitPriceText.Text = input.UnitPriceText;
+            _categoryText.Text = input.Category;
         }
 
         internal void ClearInput() {
@@ -177,7 +182,12 @@ namespace Sales_Management_App.Presentation.Tabs.Products {
         }
 
         private static string ToText(object value) {
-            return value == null ? string.Empty : value.ToString();
+            return value?.ToString() ?? string.Empty;
+        }
+
+        private static int ToInt32(object value) {
+            int parsed;
+            return int.TryParse(ToText(value), out parsed) ? parsed : 0;
         }
 
         private static TextBox AddLabeledTextBox(TableLayoutPanel panel, string label, int col, int row) {

--- a/Sales Management App/Sales Management App/Presentation/Tabs/Sales/SalesController.cs
+++ b/Sales Management App/Sales Management App/Presentation/Tabs/Sales/SalesController.cs
@@ -45,8 +45,7 @@ namespace Sales_Management_App.Presentation.Tabs.Sales {
         }
 
         internal void RefreshProductOptions() {
-            var selected = _view.GetSelectedProductOption();
-            var selectedId = selected == null ? string.Empty : selected.ProductId;
+            var selectedId = _view.GetSelectedProductOption()?.ProductId ?? string.Empty;
             var options = _productService.GetAll(_appState.Products).Select(p => new SaleProductOption {
                 ProductId = p.ProductId,
                 ProductName = p.ProductName,
@@ -69,7 +68,7 @@ namespace Sales_Management_App.Presentation.Tabs.Sales {
                 SaleDate = s.SaleDate.ToString("yyyy/MM/dd"),
                 StoreId = s.StoreId,
                 ProductId = s.ProductId,
-                ProductName = productNameMap.ContainsKey(s.ProductId) ? productNameMap[s.ProductId] : "(未登録商品)",
+                ProductName = ResolveProductName(productNameMap, s.ProductId),
                 Quantity = s.Quantity,
                 SalesAmount = s.SalesAmount
             }).ToList();
@@ -152,6 +151,17 @@ namespace Sales_Management_App.Presentation.Tabs.Sales {
                 ProductId = input.ProductId,
                 Quantity = quantity
             };
+        }
+
+        private static string ResolveProductName(
+            System.Collections.Generic.IReadOnlyDictionary<string, string> productNameMap,
+            string productId) {
+            string productName;
+            if (productNameMap.TryGetValue(productId, out productName)) {
+                return productName;
+            }
+
+            return "(未登録商品)";
         }
     }
 }


### PR DESCRIPTION
﻿## 目的
- 可読性・書式規約（早期return、冗長条件の削減、読みやすい変換処理）を既存コードへ適用する。

## 変更点
- `InventoryView` / `ProductsView`
  - `SetInput` の null分岐を早期return化
  - セル値→数値変換を `ToInt32` ヘルパーへ集約
  - `ToText` を null合体演算子で簡潔化
- `SalesController`
  - 選択商品ID取得を null合体演算子で簡潔化
  - 商品名解決を `ResolveProductName` に分離し、辞書参照を可読化

## 確認結果
- [x] `dotnet build "Sales Management App/Sales Management App.slnx"` 成功
- [x] `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj` 成功 (69/69)

Closes #80
