### PR TITLE
[#39] コメント規約（XMLドキュメント）を公開メンバーへ適用

### DIFF
--- a/Sales Management App/Sales Management App/Form1.cs
+++ b/Sales Management App/Sales Management App/Form1.cs
@@ -11,6 +11,9 @@ using Sales_Management_App.Presentation.Tabs.Products;
 using Sales_Management_App.Presentation.Tabs.Sales;
 
 namespace Sales_Management_App {
+    /// <summary>
+    /// 販売管理アプリケーションのメインフォームです。
+    /// </summary>
     public partial class Form1 : Form {
         private readonly ProductService _productService;
         private readonly InventoryService _inventoryService;
@@ -35,6 +38,9 @@ namespace Sales_Management_App {
         private AggregationView _aggregationView;
         private AggregationController _aggregationController;
 
+        /// <summary>
+        /// 依存関係を既定設定で初期化してフォームを生成します。
+        /// </summary>
         public Form1()
             : this(MainFormDependencies.CreateDefault()) {
         }

--- a/Sales Management App/Sales Management App/Presentation/Tabs/Aggregation/AggregationProductSummaryRow.cs
+++ b/Sales Management App/Sales Management App/Presentation/Tabs/Aggregation/AggregationProductSummaryRow.cs
@@ -1,9 +1,18 @@
 namespace Sales_Management_App.Presentation.Tabs.Aggregation {
     internal sealed class AggregationProductSummaryRow {
+        /// <summary>
+        /// 商品IDを取得または設定します。
+        /// </summary>
         public string ProductId { get; set; }
 
+        /// <summary>
+        /// 合計数量を取得または設定します。
+        /// </summary>
         public int TotalQuantity { get; set; }
 
+        /// <summary>
+        /// 合計売上金額を取得または設定します。
+        /// </summary>
         public int TotalSalesAmount { get; set; }
     }
 }

--- a/Sales Management App/Sales Management App/Presentation/Tabs/Aggregation/AggregationSnapshot.cs
+++ b/Sales Management App/Sales Management App/Presentation/Tabs/Aggregation/AggregationSnapshot.cs
@@ -4,14 +4,29 @@ using SalesManagementApp.Core.Application.Models;
 
 namespace Sales_Management_App.Presentation.Tabs.Aggregation {
     internal sealed class AggregationSnapshot {
+        /// <summary>
+        /// 集計開始日を取得または設定します。
+        /// </summary>
         public DateTime StartDate { get; set; }
 
+        /// <summary>
+        /// 集計終了日を取得または設定します。
+        /// </summary>
         public DateTime EndDate { get; set; }
 
+        /// <summary>
+        /// 商品別集計結果を取得または設定します。
+        /// </summary>
         public List<ProductSalesSummary> ProductSummaries { get; set; }
 
+        /// <summary>
+        /// 週別集計結果を取得または設定します。
+        /// </summary>
         public List<WeeklySalesSummary> WeeklySummaries { get; set; }
 
+        /// <summary>
+        /// 集計期間内の総売上金額を取得または設定します。
+        /// </summary>
         public int TotalSalesAmount { get; set; }
     }
 }

--- a/Sales Management App/Sales Management App/Presentation/Tabs/Aggregation/AggregationWeeklySummaryRow.cs
+++ b/Sales Management App/Sales Management App/Presentation/Tabs/Aggregation/AggregationWeeklySummaryRow.cs
@@ -1,9 +1,18 @@
 namespace Sales_Management_App.Presentation.Tabs.Aggregation {
     internal sealed class AggregationWeeklySummaryRow {
+        /// <summary>
+        /// 週の表示文字列を取得または設定します。
+        /// </summary>
         public string Week { get; set; }
 
+        /// <summary>
+        /// 週の合計数量を取得または設定します。
+        /// </summary>
         public int TotalQuantity { get; set; }
 
+        /// <summary>
+        /// 週の合計売上金額を取得または設定します。
+        /// </summary>
         public int TotalSalesAmount { get; set; }
     }
 }

--- a/Sales Management App/Sales Management App/Presentation/Tabs/Inventory/InventoryViewRow.cs
+++ b/Sales Management App/Sales Management App/Presentation/Tabs/Inventory/InventoryViewRow.cs
@@ -1,9 +1,18 @@
 namespace Sales_Management_App.Presentation.Tabs.Inventory {
     internal sealed class InventoryViewRow {
+        /// <summary>
+        /// 店舗IDを取得または設定します。
+        /// </summary>
         public string StoreId { get; set; }
 
+        /// <summary>
+        /// 商品IDを取得または設定します。
+        /// </summary>
         public string ProductId { get; set; }
 
+        /// <summary>
+        /// 在庫数を取得または設定します。
+        /// </summary>
         public int Stock { get; set; }
     }
 }

--- a/Sales Management App/Sales Management App/Presentation/Tabs/InventoryHistory/InventoryHistoryOperationFilterOption.cs
+++ b/Sales Management App/Sales Management App/Presentation/Tabs/InventoryHistory/InventoryHistoryOperationFilterOption.cs
@@ -1,12 +1,23 @@
 namespace Sales_Management_App.Presentation.Tabs.InventoryHistory {
     internal sealed class InventoryHistoryOperationFilterOption {
+        /// <summary>
+        /// フィルタ選択肢を初期化します。
+        /// </summary>
+        /// <param name="value">選択肢の内部値。</param>
+        /// <param name="label">画面表示ラベル。</param>
         public InventoryHistoryOperationFilterOption(string value, string label) {
             Value = value;
             Label = label;
         }
 
+        /// <summary>
+        /// 選択肢の内部値を取得します。
+        /// </summary>
         public string Value { get; private set; }
 
+        /// <summary>
+        /// 選択肢の表示ラベルを取得します。
+        /// </summary>
         public string Label { get; private set; }
     }
 }

--- a/Sales Management App/Sales Management App/Presentation/Tabs/InventoryHistory/InventoryHistoryViewRow.cs
+++ b/Sales Management App/Sales Management App/Presentation/Tabs/InventoryHistory/InventoryHistoryViewRow.cs
@@ -1,17 +1,38 @@
 namespace Sales_Management_App.Presentation.Tabs.InventoryHistory {
     internal sealed class InventoryHistoryViewRow {
+        /// <summary>
+        /// 発生日時の表示文字列を取得または設定します。
+        /// </summary>
         public string OccurredAt { get; set; }
 
+        /// <summary>
+        /// 操作種別の表示文字列を取得または設定します。
+        /// </summary>
         public string OperationType { get; set; }
 
+        /// <summary>
+        /// 店舗IDを取得または設定します。
+        /// </summary>
         public string StoreId { get; set; }
 
+        /// <summary>
+        /// 商品IDを取得または設定します。
+        /// </summary>
         public string ProductId { get; set; }
 
+        /// <summary>
+        /// 操作数量を取得または設定します。
+        /// </summary>
         public int Quantity { get; set; }
 
+        /// <summary>
+        /// 操作後在庫数を取得または設定します。
+        /// </summary>
         public int ResultStock { get; set; }
 
+        /// <summary>
+        /// 処理結果を取得または設定します。
+        /// </summary>
         public string Result { get; set; }
     }
 }

--- a/Sales Management App/Sales Management App/Presentation/Tabs/Products/ProductViewRow.cs
+++ b/Sales Management App/Sales Management App/Presentation/Tabs/Products/ProductViewRow.cs
@@ -1,11 +1,23 @@
 namespace Sales_Management_App.Presentation.Tabs.Products {
     internal sealed class ProductViewRow {
+        /// <summary>
+        /// 商品IDを取得または設定します。
+        /// </summary>
         public string ProductId { get; set; }
 
+        /// <summary>
+        /// 商品名を取得または設定します。
+        /// </summary>
         public string ProductName { get; set; }
 
+        /// <summary>
+        /// 単価を取得または設定します。
+        /// </summary>
         public int UnitPrice { get; set; }
 
+        /// <summary>
+        /// カテゴリを取得または設定します。
+        /// </summary>
         public string Category { get; set; }
     }
 }

--- a/Sales Management App/Sales Management App/Presentation/Tabs/Sales/SaleProductOption.cs
+++ b/Sales Management App/Sales Management App/Presentation/Tabs/Sales/SaleProductOption.cs
@@ -1,11 +1,23 @@
 namespace Sales_Management_App.Presentation.Tabs.Sales {
     internal sealed class SaleProductOption {
+        /// <summary>
+        /// 商品IDを取得または設定します。
+        /// </summary>
         public string ProductId { get; set; }
 
+        /// <summary>
+        /// 商品名を取得または設定します。
+        /// </summary>
         public string ProductName { get; set; }
 
+        /// <summary>
+        /// 単価を取得または設定します。
+        /// </summary>
         public int UnitPrice { get; set; }
 
+        /// <summary>
+        /// コンボボックス表示用の文字列を取得します。
+        /// </summary>
         public string DisplayText {
             get { return string.Format("{0} - {1}", ProductId, ProductName); }
         }

--- a/Sales Management App/Sales Management App/Presentation/Tabs/Sales/SalesViewRow.cs
+++ b/Sales Management App/Sales Management App/Presentation/Tabs/Sales/SalesViewRow.cs
@@ -1,15 +1,33 @@
 namespace Sales_Management_App.Presentation.Tabs.Sales {
     internal sealed class SalesViewRow {
+        /// <summary>
+        /// 売上日を取得または設定します。
+        /// </summary>
         public string SaleDate { get; set; }
 
+        /// <summary>
+        /// 店舗IDを取得または設定します。
+        /// </summary>
         public string StoreId { get; set; }
 
+        /// <summary>
+        /// 商品IDを取得または設定します。
+        /// </summary>
         public string ProductId { get; set; }
 
+        /// <summary>
+        /// 商品名を取得または設定します。
+        /// </summary>
         public string ProductName { get; set; }
 
+        /// <summary>
+        /// 数量を取得または設定します。
+        /// </summary>
         public int Quantity { get; set; }
 
+        /// <summary>
+        /// 売上金額を取得または設定します。
+        /// </summary>
         public int SalesAmount { get; set; }
     }
 }


### PR DESCRIPTION
﻿## 概要
Issue #81 の対応として、WinForms本体の `public` メンバーにXMLドキュメントコメントを付与しました。

## 変更内容
- `Form1` の公開クラス/公開コンストラクタへXMLコメントを追加
- 各タブの表示行モデル・選択肢モデルの公開プロパティ/公開コンストラクタへXMLコメントを追加
  - Products / Inventory / InventoryHistory / Sales / Aggregation
- 履歴系コメント（`Add by ...` など）や `Todo/Hack/Undone` を含むコメントがないことを確認

## 動作確認
- `dotnet build "Sales Management App/Sales Management App.slnx"` : 成功
- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj` : 成功（69 passed）

## 補足
- 生成コード（`*.Designer.cs`）は対象外です。

Closes #81
