### PR TITLE
[#40] 規約適用後の回帰確認と逸脱管理を実施

### DIFF
--- a/docs/coding-conventions-deviation-log.md
+++ b/docs/coding-conventions-deviation-log.md
@@ -1,0 +1,27 @@
+# コーディング規約 逸脱管理台帳（Issue #82）
+
+## 1. 目的
+- `CODING_CONVENTIONS.md` 適用後に残る規約逸脱を、理由と対応方針つきで継続管理する。
+
+## 2. 回帰確認結果（2026-03-04）
+- `dotnet build "Sales Management App/Sales Management App.slnx"`: 成功（0 warnings / 0 errors）
+- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj`: 成功（69 passed）
+- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj --filter "FullyQualifiedName~WeeklyFlowE2ETests"`: 成功（1 passed）
+
+## 3. 適用済み規約（今回まで）
+- 命名規約の主要部分を適用（Issue #79）
+- 可読性・書式・using順序を適用（Issue #80）
+- WinForms本体の公開メンバーにXMLドキュメントコメントを適用（Issue #81）
+
+## 4. 逸脱一覧
+
+| ID | 規約項目 | 対象 | 現状 | 理由 | 対応方針 |
+|---|---|---|---|---|---|
+| DEV-001 | クラス接尾辞規約（例: `Control`） | 画面制御クラス | `...Controller` を使用 | 本プロジェクトは MVC/MVP 寄りの責務分離方針で統一済み | 方針維持。命名例外として継続管理（`docs/coding-conventions-naming-exceptions.md`） |
+| DEV-002 | 変数接頭辞規約（`F` / `v` / `w` / `C_`） | 全体 | 現代的C#スタイル（接頭辞なし）を使用 | 可読性と .NET 標準慣習を優先 | 方針維持。命名例外として継続管理（`docs/coding-conventions-naming-exceptions.md`） |
+| DEV-003 | `public/protected` へのXMLコメント付与 | `src/SalesManagementApp.Core` | 未付与が 135 宣言残存 | 既存公開APIへのコメント付与は差分が大きく、今回Issueのスコープ外 | 専用Issueで段階的に対応（サービス層→状態管理→ドメイン/インフラの順） |
+
+## 5. 補足（計測方法）
+- 未付与件数（DEV-003）は次のコマンドで抽出した。
+  - `rg -n "^\s*(public|protected)\b" src -g "*.cs"`
+  - 上記宣言に対して、直前の非空行が `///` で始まるかを確認するスクリプトで集計

--- a/docs/e2e-test-report.md
+++ b/docs/e2e-test-report.md
@@ -22,3 +22,15 @@
 - 実行コマンド:
   - `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj`
 
+## 回帰確認（2026-03-04）
+- 実施目的: コーディング規約適用後の回帰確認（Issue #82）
+- 判定: `OK`
+- 実行コマンド:
+  - `dotnet build "Sales Management App/Sales Management App.slnx"`
+  - `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj`
+  - `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj --filter "FullyQualifiedName~WeeklyFlowE2ETests"`
+- 実行結果:
+  - build: 成功（0 warnings / 0 errors）
+  - unit+integration+e2e: 69 passed
+  - WeeklyFlowE2E（絞り込み実行）: 1 passed
+


### PR DESCRIPTION
﻿## 概要
Issue #82 の対応として、規約適用後の回帰確認結果を記録し、残存する規約逸脱を台帳化しました。

## 変更内容
- `docs/e2e-test-report.md`
  - 2026-03-04 の回帰確認結果（build/test/E2E）を追記
- `docs/coding-conventions-deviation-log.md`
  - 逸脱一覧（理由・根拠・対応方針）を新規作成
  - 命名例外（Controller接尾辞、接頭辞規約）を継続管理対象として整理
  - Core層のXMLコメント未付与（135宣言）を残課題として明文化

## 回帰確認（ローカル）
- `dotnet build "Sales Management App/Sales Management App.slnx"` : 成功（0 warnings / 0 errors）
- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj` : 成功（69 passed）
- `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj --filter "FullyQualifiedName~WeeklyFlowE2ETests"` : 成功（1 passed）

## 規約適用の整理
### 適用できた規約
- build/test/E2E の回帰確認運用
- 規約逸脱の明文化（差分・理由・今後方針）

### 見送った規約
- `src/SalesManagementApp.Core` の `public/protected` 全宣言へのXMLコメント付与

### 見送り理由
- 既存公開APIに対する広範囲差分となるため、回帰確認Issue（#82）のスコープ外
- 本PRでは「逸脱管理台帳」に記録し、段階適用前提で追跡可能化

Closes #82
