### PR TITLE
feat: 配布フォルダ生成と起動パス解決を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 - `dotnet build "Sales Management App/Sales Management App.slnx"`
 - `dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj`
 
+## 配布手順
+1. Visual Studio で `Sales Management App/Sales Management App/Sales Management App.csproj` を `Release` ビルドする
+2. リポジトリルートで `powershell -ExecutionPolicy Bypass -File .\scripts\Create-Distribution.ps1 -Clean` を実行する
+3. `dist/SalesManagementApp` フォルダをまとめて配布する
+
+配布先PCでは、`Sales Management App.exe`、`SalesManagementApp.Core.dll`、`Sales Management App.exe.config`、各CSVを同じフォルダに置いたまま起動する。
+
 ## 主要ドキュメント
 - 利用者向け手順: `docs/user-operation-manual.md`
 - 開発者向け手順: `docs/developer-setup.md`

--- a/scripts/Create-Distribution.ps1
+++ b/scripts/Create-Distribution.ps1
@@ -1,0 +1,89 @@
+[CmdletBinding()]
+param(
+    [string]$Configuration = "Release",
+    [string]$OutputDirectory = "",
+    [switch]$Clean
+)
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repositoryRoot = Split-Path -Parent $scriptRoot
+$applicationOutput = Join-Path $repositoryRoot "Sales Management App\Sales Management App\bin\$Configuration"
+
+if ([string]::IsNullOrWhiteSpace($OutputDirectory))
+{
+    $OutputDirectory = Join-Path $repositoryRoot "dist\SalesManagementApp"
+}
+
+$requiredApplicationFiles = @(
+    "Sales Management App.exe",
+    "Sales Management App.exe.config",
+    "SalesManagementApp.Core.dll"
+)
+
+$distributionDataFiles = @(
+    "products.csv",
+    "inventory.csv",
+    "inventory_history.csv",
+    "週次売上集計ファイル.xlsx"
+)
+
+if (!(Test-Path $applicationOutput))
+{
+    throw "Build output not found: $applicationOutput . Build the WinForms project in Visual Studio with Configuration=$Configuration first."
+}
+
+$missingApplicationFiles = $requiredApplicationFiles | Where-Object {
+    !(Test-Path (Join-Path $applicationOutput $_))
+}
+
+if ($missingApplicationFiles.Count -gt 0)
+{
+    $missingList = $missingApplicationFiles -join ", "
+    throw "Distribution source files are missing from build output: $missingList"
+}
+
+if ($Clean -and (Test-Path $OutputDirectory))
+{
+    Remove-Item -Recurse -Force $OutputDirectory
+}
+
+New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+
+foreach ($fileName in $requiredApplicationFiles)
+{
+    Copy-Item (Join-Path $applicationOutput $fileName) $OutputDirectory -Force
+}
+
+foreach ($fileName in $distributionDataFiles)
+{
+    $sourcePath = Join-Path $repositoryRoot $fileName
+    if (Test-Path $sourcePath)
+    {
+        Copy-Item $sourcePath $OutputDirectory -Force
+    }
+}
+
+$latestSalesFile = Get-ChildItem -Path $repositoryRoot -Filter "sales_*.csv" -File |
+    Where-Object { $_.Name -match '^sales_\d{8}\.csv$' } |
+    Sort-Object Name -Descending |
+    Select-Object -First 1
+
+if ($null -ne $latestSalesFile)
+{
+    Copy-Item $latestSalesFile.FullName $OutputDirectory -Force
+}
+
+$readmePath = Join-Path $OutputDirectory "README-distribution.txt"
+$readmeLines = @(
+    "Sales Management App distribution folder",
+    "",
+    "1. Install .NET Framework 4.7.2 or later on the target PC.",
+    "2. Keep the exe, dll, config, and CSV files in this same folder.",
+    "3. Start 'Sales Management App.exe'.",
+    "",
+    "Generated: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')",
+    "Source build: $applicationOutput"
+)
+Set-Content -Path $readmePath -Value $readmeLines -Encoding UTF8
+
+Write-Output "Distribution folder created: $OutputDirectory"

--- a/src/SalesManagementApp.Core/Application/State/AppBootstrapper.cs
+++ b/src/SalesManagementApp.Core/Application/State/AppBootstrapper.cs
@@ -24,12 +24,12 @@ public class AppBootstrapper
 
     public AppState LoadFromBaseDirectory(string baseDirectory)
     {
-        var rootPath = FindRepositoryRoot(baseDirectory);
-        if (string.IsNullOrWhiteSpace(rootPath))
+        if (string.IsNullOrWhiteSpace(baseDirectory))
         {
             return new AppState();
         }
 
+        var rootPath = ResolveDataRoot(baseDirectory);
         var state = new AppState
         {
             RepositoryRootPath = rootPath,
@@ -45,6 +45,17 @@ public class AppBootstrapper
         state.InventoryHistories.AddRange(_repository.ReadInventoryHistoriesIfExists(state.InventoryHistoryPath));
 
         return state;
+    }
+
+    private static string ResolveDataRoot(string baseDirectory)
+    {
+        var repositoryRoot = FindRepositoryRoot(baseDirectory);
+        if (!string.IsNullOrWhiteSpace(repositoryRoot))
+        {
+            return repositoryRoot;
+        }
+
+        return Path.GetFullPath(baseDirectory);
     }
 
     private static string FindRepositoryRoot(string baseDirectory)

--- a/tests/SalesManagementApp.Tests/AppState/AppBootstrapperTests.cs
+++ b/tests/SalesManagementApp.Tests/AppState/AppBootstrapperTests.cs
@@ -74,17 +74,53 @@ public class AppBootstrapperTests
     }
 
     [Test]
-    public void LoadFromBaseDirectory_WhenRepositoryRootNotFound_ReturnsEmptyState()
+    public void LoadFromBaseDirectory_WhenRepositoryRootNotFound_UsesBaseDirectoryAsDataRoot()
     {
         var baseDir = Path.Combine(_workDir, "standalone");
+        Directory.CreateDirectory(baseDir);
+        File.WriteAllLines(Path.Combine(baseDir, "products.csv"), new[]
+        {
+            "ProductId,ProductName,UnitPrice,Category",
+            "P001,Cola,120,Drink"
+        });
+        File.WriteAllLines(Path.Combine(baseDir, "inventory.csv"), new[]
+        {
+            "StoreId,ProductId,Stock",
+            "S001,P001,10"
+        });
+        File.WriteAllLines(Path.Combine(baseDir, "sales_20260303.csv"), new[]
+        {
+            "SaleDate,StoreId,ProductId,Quantity,SalesAmount",
+            "2026-03-03,S001,P001,1,120"
+        });
+
+        var state = _bootstrapper.LoadFromBaseDirectory(baseDir);
+
+        Assert.That(state.RepositoryRootPath, Is.EqualTo(baseDir));
+        Assert.That(state.Products.Count, Is.EqualTo(1));
+        Assert.That(state.Inventories.Count, Is.EqualTo(1));
+        Assert.That(state.Sales.Count, Is.EqualTo(1));
+        Assert.That(state.ProductsPath, Is.EqualTo(Path.Combine(baseDir, "products.csv")));
+        Assert.That(state.InventoryPath, Is.EqualTo(Path.Combine(baseDir, "inventory.csv")));
+        Assert.That(state.SalesPath, Is.EqualTo(Path.Combine(baseDir, "sales_20260303.csv")));
+        Assert.That(state.InventoryHistoryPath, Is.EqualTo(Path.Combine(baseDir, "inventory_history.csv")));
+    }
+
+    [Test]
+    public void LoadFromBaseDirectory_WhenRepositoryRootNotFoundAndDataFilesMissing_UsesBaseDirectoryWithEmptyState()
+    {
+        var baseDir = Path.Combine(_workDir, "empty-standalone");
         Directory.CreateDirectory(baseDir);
 
         var state = _bootstrapper.LoadFromBaseDirectory(baseDir);
 
-        Assert.That(state.RepositoryRootPath, Is.Empty);
+        Assert.That(state.RepositoryRootPath, Is.EqualTo(baseDir));
         Assert.That(state.Products, Is.Empty);
         Assert.That(state.Inventories, Is.Empty);
         Assert.That(state.Sales, Is.Empty);
         Assert.That(state.InventoryHistories, Is.Empty);
+        Assert.That(state.ProductsPath, Is.EqualTo(Path.Combine(baseDir, "products.csv")));
+        Assert.That(state.InventoryPath, Is.EqualTo(Path.Combine(baseDir, "inventory.csv")));
+        Assert.That(state.InventoryHistoryPath, Is.EqualTo(Path.Combine(baseDir, "inventory_history.csv")));
     }
 }


### PR DESCRIPTION
## 目的
- exe 直接起動時の配布条件を明確にし、配布フォルダから起動できる状態を正式サポートする
- Release ビルド成果物と必要データをまとめて配布できるようにする

## 変更点
- AppBootstrapper を修正し、AGENTS.md がない環境でも起動フォルダをデータルートとして扱えるように変更
- 配布フォルダ生成用の scripts/Create-Distribution.ps1 を追加
- 配布フォルダ前提の起動テストを AppBootstrapperTests に追加
- README に配布手順を追記

## 確認結果
- dotnet test tests/SalesManagementApp.Tests/SalesManagementApp.Tests.csproj : 70件成功
- MSBuild.exe 'Sales Management App/Sales Management App/Sales Management App.csproj' /t:Build /p:Configuration=Release /nologo : 成功
- powershell -ExecutionPolicy Bypass -File .\scripts\Create-Distribution.ps1 -Clean : 成功
- 生成した dist/SalesManagementApp/Sales Management App.exe の直接起動 : 成功